### PR TITLE
various: verify stage1 and stage2 activation; cleanup

### DIFF
--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -19,6 +19,174 @@ use nix::{
   unistd::{chdir, chroot, execv, getpid},
 };
 
+#[derive(Debug)]
+enum DeviceManager {
+  Udev { udevd: PathBuf, udevadm: PathBuf },
+  Mdev { mdev: PathBuf },
+}
+
+impl Default for DeviceManager {
+  fn default() -> Self {
+    Self::Udev {
+      udevd:   PathBuf::from("systemd-udevd"),
+      udevadm: PathBuf::from("udevadm"),
+    }
+  }
+}
+
+impl DeviceManager {
+  fn from_env(extra_utils: Option<&Path>) -> Self {
+    match env::var("DEVICE_MANAGER").as_deref() {
+      Ok("mdev") => {
+        Self::Mdev {
+          mdev: env::var("MDEV_BINARY").map(PathBuf::from).unwrap_or_else(
+            |_| {
+              extra_utils
+                .map_or_else(|| PathBuf::from("mdev"), |u| u.join("bin/mdev"))
+            },
+          ),
+        }
+      },
+      _ => {
+        Self::Udev {
+          udevd:   env::var("UDEV_BINARY").map(PathBuf::from).unwrap_or_else(
+            |_| {
+              extra_utils.map_or_else(
+                || PathBuf::from("systemd-udevd"),
+                |u| u.join("bin/systemd-udevd"),
+              )
+            },
+          ),
+          udevadm: env::var("UDEVADM_BINARY")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+              extra_utils.map_or_else(
+                || PathBuf::from("udevadm"),
+                |u| u.join("bin/udevadm"),
+              )
+            }),
+        }
+      },
+    }
+  }
+
+  fn start(&self, rules_path: Option<&Path>) -> Result<()> {
+    log_message("Starting device manager...", true);
+    match self {
+      Self::Udev { udevd, .. } => {
+        if let Some(rules) = rules_path {
+          let rules_dir = Path::new("/etc/udev/rules.d");
+          fs::create_dir_all(rules_dir)?;
+          if rules.is_dir() {
+            for entry in fs::read_dir(rules)? {
+              let entry = entry?;
+              fs::copy(entry.path(), rules_dir.join(entry.file_name()))?;
+            }
+          }
+        }
+        let conf = Path::new("/etc/udev/udev.conf");
+        if !conf.exists() {
+          fs::create_dir_all(conf.parent().unwrap())?;
+          fs::write(conf, "udev_log=err\n")?;
+        }
+        Command::new(udevd)
+          .arg("--daemon")
+          .status()
+          .with_context(|| {
+            format!("Failed to start udevd: {}", udevd.display())
+          })?;
+      },
+      Self::Mdev { mdev } => {
+        // -d: listen for kernel hotplug events; -s: initial coldplug scan.
+        Command::new(mdev).arg("-d").status().with_context(|| {
+          format!("Failed to start mdev: {}", mdev.display())
+        })?;
+        Command::new(mdev).arg("-s").status().with_context(|| {
+          format!("mdev coldplug scan failed: {}", mdev.display())
+        })?;
+      },
+    }
+    log_message("Device manager started", true);
+    Ok(())
+  }
+
+  fn trigger(&self) -> Result<()> {
+    log_message("Triggering device events...", true);
+    match self {
+      Self::Udev { udevadm, .. } => {
+        Command::new(udevadm)
+          .args(["trigger", "--action=add"])
+          .status()
+          .context("Failed to trigger udev events")?;
+      },
+      Self::Mdev { .. } => {
+        // Covered by the -s scan in start(); nothing more to do.
+      },
+    }
+    Ok(())
+  }
+
+  fn settle(&self) -> Result<()> {
+    log_message("Waiting for device manager to settle...", true);
+    match self {
+      Self::Udev { udevadm, .. } => {
+        let status = Command::new(udevadm)
+          .args(["settle", "--timeout=30"])
+          .status()
+          .context("Failed to wait for udev")?;
+        if !status.success() {
+          log_message("Warning: udev settle timed out", true);
+        }
+      },
+      Self::Mdev { .. } => {
+        // mdev -s is synchronous; no separate settle step.
+      },
+    }
+    Ok(())
+  }
+
+  // Best-effort block re-trigger used in device-polling loops; errors are
+  // swallowed.
+  fn retrigger_block(&self) {
+    match self {
+      Self::Udev { udevadm, .. } => {
+        let _ = Command::new(udevadm)
+          .args(["trigger", "--subsystem-match=block", "--action=change"])
+          .status();
+        let _ = Command::new(udevadm)
+          .args(["settle", "--timeout=3"])
+          .status();
+      },
+      Self::Mdev { mdev } => {
+        let _ = Command::new(mdev).arg("-s").status();
+      },
+    }
+  }
+
+  fn stop(&self) {
+    log_message("Stopping device manager...", true);
+    match self {
+      Self::Udev { udevadm, .. } => {
+        let _ = Command::new(udevadm).args(["control", "--exit"]).status();
+      },
+      Self::Mdev { mdev } => {
+        let name = mdev.file_name().unwrap_or(mdev.as_os_str());
+        let _ = Command::new("pkill").arg(name).status();
+      },
+    }
+  }
+
+  // Write /dev/root udev rule so systemd's mount-unit generator can find the
+  // root device. mdev does not process /run/udev/rules.d, so this is a no-op
+  // for that backend.
+  fn write_dev_root_rule(&self, target_root: &Path) -> Result<()> {
+    match self {
+      Self::Udev { .. } => write_dev_root_udev_rule(target_root),
+      Self::Mdev { .. } => Ok(()),
+    }
+  }
+}
+
 #[derive(Debug, Default)]
 struct Stage1Config {
   target_root:          PathBuf,
@@ -39,6 +207,8 @@ struct Stage1Config {
   check_journaling_fs:  bool,
   set_host_id:          Option<String>,
   distro_name:          String,
+  device_manager:       DeviceManager,
+  link_units_dest:      PathBuf,
 }
 
 #[derive(Debug, Default)]
@@ -149,43 +319,49 @@ impl KernelCmdline {
 
 impl Stage1Config {
   fn from_env() -> Self {
+    let extra_utils: Option<PathBuf> =
+      env::var("extraUtils").ok().map(PathBuf::from);
+    let device_manager = DeviceManager::from_env(extra_utils.as_deref());
+
     Self {
-      target_root:          env::var("targetRoot")
+      target_root: env::var("targetRoot")
         .map_or_else(|_| PathBuf::from("/mnt-root"), PathBuf::from),
-      extra_utils:          env::var("extraUtils").ok().map(PathBuf::from),
-      kernel_modules:       env::var("kernelModules")
+      extra_utils,
+      kernel_modules: env::var("kernelModules")
         .map(|mods| mods.split_whitespace().map(String::from).collect())
         .unwrap_or_default(),
-      resume_device:        env::var("resumeDevice").ok(),
-      resume_devices:       env::var("resumeDevices")
+      resume_device: env::var("resumeDevice").ok(),
+      resume_devices: env::var("resumeDevices")
         .map(|devs| devs.split_whitespace().map(String::from).collect())
         .unwrap_or_default(),
-      fs_info:              env::var("fsInfo").ok().map(PathBuf::from),
-      pre_fail_commands:    env::var("preFailCommands").ok().map(PathBuf::from),
-      pre_device_commands:  env::var("preDeviceCommands")
+      fs_info: env::var("fsInfo").ok().map(PathBuf::from),
+      pre_fail_commands: env::var("preFailCommands").ok().map(PathBuf::from),
+      pre_device_commands: env::var("preDeviceCommands")
         .ok()
         .map(PathBuf::from),
-      pre_lvm_commands:     env::var("preLVMCommands").ok().map(PathBuf::from),
+      pre_lvm_commands: env::var("preLVMCommands").ok().map(PathBuf::from),
       post_device_commands: env::var("postDeviceCommands")
         .ok()
         .map(PathBuf::from),
       post_resume_commands: env::var("postResumeCommands")
         .ok()
         .map(PathBuf::from),
-      post_mount_commands:  env::var("postMountCommands")
+      post_mount_commands: env::var("postMountCommands")
         .ok()
         .map(PathBuf::from),
-      early_mount_script:   env::var("earlyMountScript")
-        .ok()
-        .map(PathBuf::from),
-      udev_rules:           env::var("udevRules").ok().map(PathBuf::from),
-      link_units:           env::var("linkUnits").ok().map(PathBuf::from),
-      check_journaling_fs:  env::var("checkJournalingFS")
+      early_mount_script: env::var("earlyMountScript").ok().map(PathBuf::from),
+      udev_rules: env::var("udevRules").ok().map(PathBuf::from),
+      link_units: env::var("linkUnits").ok().map(PathBuf::from),
+      check_journaling_fs: env::var("checkJournalingFS")
         .map(|v| v != "0" && v != "false")
         .unwrap_or(true),
-      set_host_id:          env::var("HOST_ID").ok(),
-      distro_name:          env::var("distroName")
+      set_host_id: env::var("HOST_ID").ok(),
+      distro_name: env::var("distroName")
         .unwrap_or_else(|_| "NixOS".to_string()),
+      device_manager,
+      link_units_dest: env::var("LINK_UNITS_DEST")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/etc/systemd/network")),
     }
   }
 }
@@ -438,8 +614,13 @@ fn is_mounted(path: &Path) -> bool {
   false
 }
 
-// Wait up to timeout_secs for device to appear; re-triggers udev periodically.
-fn wait_for_device(device: &str, timeout_secs: u64) -> Result<()> {
+// Wait up to timeout_secs for device to appear; re-triggers the device manager
+// periodically.
+fn wait_for_device(
+  device: &str,
+  timeout_secs: u64,
+  dm: &DeviceManager,
+) -> Result<()> {
   let device_path = Path::new(device);
   let start = Instant::now();
   let timeout = Duration::from_secs(timeout_secs);
@@ -453,14 +634,8 @@ fn wait_for_device(device: &str, timeout_secs: u64) -> Result<()> {
       return Ok(());
     }
 
-    // Re-trigger udev every 5 seconds so block events aren't missed.
     if last_retrigger.elapsed() >= Duration::from_secs(5) {
-      let _ = Command::new("udevadm")
-        .args(["trigger", "--subsystem-match=block", "--action=change"])
-        .status();
-      let _ = Command::new("udevadm")
-        .args(["settle", "--timeout=3"])
-        .status();
+      dm.retrigger_block();
       last_retrigger = Instant::now();
     }
 
@@ -508,87 +683,14 @@ fn load_kernel_modules(modules: &[String], no_modprobe: bool) -> Result<()> {
   Ok(())
 }
 
-fn setup_link_units(link_units: &Path) -> Result<()> {
-  fs::create_dir_all("/etc/systemd")?;
-  let dest = Path::new("/etc/systemd/network");
+fn setup_link_units(link_units: &Path, dest: &Path) -> Result<()> {
+  if let Some(parent) = dest.parent() {
+    fs::create_dir_all(parent)?;
+  }
   if dest.is_symlink() || dest.exists() {
     fs::remove_file(dest)?;
   }
   symlink(link_units, dest)?;
-  Ok(())
-}
-
-// Mirrors stage-1-init.sh line 280: `systemd-udevd --daemon`
-// (systemd-udevd is a symlink to udevadm in extra-utils; there is no udevd
-// binary)
-fn start_udev(
-  rules_path: Option<&Path>,
-  extra_utils: Option<&Path>,
-) -> Result<()> {
-  log_message("Starting udevd...", true);
-
-  if let Some(rules) = rules_path {
-    let udev_rules_dir = Path::new("/etc/udev/rules.d");
-    fs::create_dir_all(udev_rules_dir)?;
-
-    if rules.is_dir() {
-      for entry in fs::read_dir(rules)? {
-        let entry = entry?;
-        let dest = udev_rules_dir.join(entry.file_name());
-        fs::copy(entry.path(), dest)?;
-      }
-    }
-  }
-
-  let udev_conf = Path::new("/etc/udev/udev.conf");
-  if !udev_conf.exists() {
-    fs::create_dir_all(udev_conf.parent().unwrap())?;
-    fs::write(udev_conf, "udev_log=err\n")?;
-  }
-
-  let udevd = extra_utils.map_or_else(
-    || PathBuf::from("systemd-udevd"),
-    |u| u.join("bin/systemd-udevd"),
-  );
-
-  Command::new(&udevd)
-    .arg("--daemon")
-    .status()
-    .map_err(|e| {
-      log_message(&format!("systemd-udevd spawn failed: {e}"), true);
-      e
-    })
-    .context("Failed to start systemd-udevd")?;
-
-  log_message("udevd started", true);
-  Ok(())
-}
-
-fn trigger_udev() -> Result<()> {
-  log_message("Triggering udev events...", true);
-
-  Command::new("udevadm")
-    .arg("trigger")
-    .arg("--action=add")
-    .status()
-    .context("Failed to trigger udev events")?;
-
-  Ok(())
-}
-
-fn settle_udev() -> Result<()> {
-  log_message("Waiting for udev to settle...", true);
-
-  let status = Command::new("udevadm")
-    .arg("settle")
-    .arg("--timeout=30")
-    .status()
-    .context("Failed to settle udev")?;
-
-  if !status.success() {
-    log_message("Warning: udev settle timed out", true);
-  }
-
   Ok(())
 }
 
@@ -939,6 +1041,7 @@ fn mount_root(
   cmdline: &KernelCmdline,
   target_root: &Path,
   fs_infos: &[FsInfo],
+  dm: &DeviceManager,
 ) -> Result<()> {
   log_message("Mounting root filesystem...", true);
 
@@ -1035,18 +1138,11 @@ fn mount_root(
         break;
       }
 
-      // Periodically re-trigger block events so udev populates by-* symlinks,
-      // and re-run `vgchange -ay` to activate LVM volumes that showed up
-      // after the initial device setup (stacked LVM / late-arriving USB /
-      // slow PVs). stage-1-init.sh does the lvm retry inline in the same
-      // loop (lines 87-120).
+      // Periodically re-trigger block events and re-run `vgchange -ay` to
+      // activate LVM volumes that showed up after initial device setup
+      // (stacked LVM / late-arriving USB / slow PVs).
       if last_retrigger.elapsed() >= Duration::from_secs(3) {
-        let _ = Command::new("udevadm")
-          .args(["trigger", "--subsystem-match=block", "--action=change"])
-          .status();
-        let _ = Command::new("udevadm")
-          .args(["settle", "--timeout=3"])
-          .status();
+        dm.retrigger_block();
         if Command::new("lvm")
           .arg("--version")
           .stdout(std::process::Stdio::null())
@@ -1213,6 +1309,7 @@ fn copy_iso_to_ram(cmdline: &KernelCmdline, target_root: &Path) -> Result<()> {
 fn handle_persistence(
   cmdline: &KernelCmdline,
   target_root: &Path,
+  dm: &DeviceManager,
 ) -> Result<()> {
   let persist_opt = match &cmdline.persistence {
     Some(p) => p.clone(),
@@ -1231,7 +1328,7 @@ fn handle_persistence(
   };
 
   if let Some(dev) = device {
-    wait_for_device(&dev, 10).ok();
+    wait_for_device(&dev, 10, dm).ok();
 
     let persist_mount = Path::new("/run/persistence");
     fs::create_dir_all(persist_mount)?;
@@ -1897,14 +1994,22 @@ pub fn run(args: &[String]) -> Result<()> {
     .context("Failed to load kernel modules")?;
 
   if let Some(link_units) = config.link_units.as_deref() {
-    setup_link_units(link_units)
+    setup_link_units(link_units, &config.link_units_dest)
       .context("Failed to set up systemd link units")?;
   }
 
-  start_udev(config.udev_rules.as_deref(), config.extra_utils.as_deref())
-    .context("Failed to start udev")?;
-  trigger_udev().context("Failed to trigger udev events")?;
-  settle_udev().context("Failed to settle udev")?;
+  config
+    .device_manager
+    .start(config.udev_rules.as_deref())
+    .context("Failed to start device manager")?;
+  config
+    .device_manager
+    .trigger()
+    .context("Failed to trigger device events")?;
+  config
+    .device_manager
+    .settle()
+    .context("Failed to settle device manager")?;
 
   // LUKS-on-LVM and similar stacked setups need a hook here to cryptsetup-open
   // devices before vgchange can scan them. stage-1-init.sh:286 injects
@@ -1949,7 +2054,12 @@ pub fn run(args: &[String]) -> Result<()> {
     Vec::new()
   };
 
-  if let Err(e) = mount_root(&cmdline, &config.target_root, &fs_infos) {
+  if let Err(e) = mount_root(
+    &cmdline,
+    &config.target_root,
+    &fs_infos,
+    &config.device_manager,
+  ) {
     fail(
       &format!("Failed to mount root filesystem: {e}"),
       &cmdline,
@@ -2031,12 +2141,14 @@ pub fn run(args: &[String]) -> Result<()> {
   run_hook_script(config.post_mount_commands.as_deref(), "post-mount commands")
     .context("Post-mount commands failed")?;
 
-  write_dev_root_udev_rule(&config.target_root)
+  config
+    .device_manager
+    .write_dev_root_rule(&config.target_root)
     .context("Failed to emit /dev/root udev rule")?;
 
   copy_iso_to_ram(&cmdline, &config.target_root)
     .context("Failed to copy ISO to RAM")?;
-  handle_persistence(&cmdline, &config.target_root)
+  handle_persistence(&cmdline, &config.target_root, &config.device_manager)
     .context("Failed to handle persistence")?;
   handle_lustrate(&config.target_root).context("Failed to handle lustrate")?;
   copy_initrd_secrets(&config.target_root)
@@ -2044,12 +2156,7 @@ pub fn run(args: &[String]) -> Result<()> {
   set_host_id(config.set_host_id.as_deref())
     .context("Failed to set host ID")?;
 
-  log_message("Stopping udevd...", true);
-  let udevadm = config
-    .extra_utils
-    .as_deref()
-    .map_or_else(|| PathBuf::from("udevadm"), |u| u.join("bin/udevadm"));
-  let _ = Command::new(&udevadm).args(["control", "--exit"]).status();
+  config.device_manager.stop();
 
   kill_remaining_processes().context("Failed to kill remaining processes")?;
 

--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -619,8 +619,8 @@ fn activate_lvm() -> Result<()> {
 fn udev_fs_type(device: &str) -> Option<String> {
   let meta = fs::metadata(device).ok()?;
   let rdev = meta.rdev();
-  let major = ((rdev >> 8) & 0xFFF) | ((rdev >> 32) & !0xFFF);
-  let minor = (rdev & 0xFF) | ((rdev >> 12) & !0xFF);
+  let major = libc::major(rdev);
+  let minor = libc::minor(rdev);
   let content =
     fs::read_to_string(format!("/run/udev/data/b{major}:{minor}")).ok()?;
   content.lines().find_map(|line| {
@@ -635,8 +635,11 @@ fn udev_fs_type(device: &str) -> Option<String> {
 
 fn has_swap_signature(device: &str) -> bool {
   // Swap header magic ("SWAPSPACE2") sits at the last 10 bytes of page 0.
-  let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
-  let offset = page_size.saturating_sub(10);
+  let page_size_raw = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+  if page_size_raw <= 0 {
+    return false;
+  }
+  let offset = (page_size_raw as u64).saturating_sub(10);
   let Ok(mut f) = File::open(device) else {
     return false;
   };
@@ -690,9 +693,8 @@ fn handle_resume(
       .context("Failed to stat resume device")
       .and_then(|meta| {
         let rdev = meta.rdev();
-        // Standard Linux major/minor extraction.
-        let major = ((rdev >> 8) & 0xFFF) | ((rdev >> 32) & !0xFFF);
-        let minor = (rdev & 0xFF) | ((rdev >> 12) & !0xFF);
+        let major = libc::major(rdev);
+        let minor = libc::minor(rdev);
         fs::write("/sys/power/resume", format!("{major}:{minor}"))
           .context("Failed to write to /sys/power/resume")
       })
@@ -1089,9 +1091,10 @@ fn mount_root(
     mount_opts.push("rw".to_string());
   }
 
-  // Check and run fsck if needed
+  // Check and run fsck if needed; propagate errors so the caller can invoke
+  // the recovery shell rather than mounting a corrupt root filesystem.
   if needs_fsck(&fstype, true) {
-    run_fsck(mount_device, &fstype, &mount_opts).ok();
+    run_fsck(mount_device, &fstype, &mount_opts)?;
   }
 
   // Mount the root filesystem
@@ -1955,8 +1958,14 @@ pub fn run(args: &[String]) -> Result<()> {
   }
 
   for fs_info in &fs_infos {
-    if needs_fsck(&fs_info.fstype, config.check_journaling_fs) {
-      run_fsck(&fs_info.device, &fs_info.fstype, &fs_info.options).ok();
+    if needs_fsck(&fs_info.fstype, config.check_journaling_fs)
+      && let Err(e) =
+        run_fsck(&fs_info.device, &fs_info.fstype, &fs_info.options)
+    {
+      log_message(
+        &format!("Warning: fsck failed on {}: {e:#}", fs_info.device),
+        true,
+      );
     }
   }
 

--- a/crates/stage2/src/bash_compat.rs
+++ b/crates/stage2/src/bash_compat.rs
@@ -534,18 +534,19 @@ fn setup_nix_store(
     );
   }
 
-  // Apply mount options if /nix/store is a separate mount
-  if is_mounted(store_path) {
-    let desired_opts: Vec<String> = args
-      .nix_store_mount_opts
-      .split(',')
-      .map(|s| s.trim().to_string())
-      .filter(|s| !s.is_empty())
-      .collect();
+  // Apply mount options *unconditionally*
+  // When /nix/store is not already a separate mountpoint (e.g., systemd initrd
+  // where only the root fs is mounted), apply_nix_store_mount_opts treats all
+  // desired options as missing and creates the bind mount itself.
+  let store_opts: Vec<String> = args
+    .nix_store_mount_opts
+    .split(',')
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+    .collect();
 
-    apply_nix_store_mount_opts(store_path, &desired_opts, log_dest)
-      .context("Failed to apply /nix/store mount options")?;
-  }
+  apply_nix_store_mount_opts(store_path, &store_opts, log_dest)
+    .context("Failed to apply /nix/store mount options")?;
 
   Ok(())
 }
@@ -555,7 +556,10 @@ fn apply_nix_store_mount_opts(
   desired_opts: &[String],
   log_dest: &Option<std::path::PathBuf>,
 ) -> Result<()> {
-  let current_opts = get_mount_options(store_path)?;
+  // Fall back to empty when the path has no separate mountpoint entry (e.g.
+  // it sits on the root fs). Treating all desired options as missing causes
+  // the bind+remount below to apply them.
+  let current_opts = get_mount_options(store_path).unwrap_or_default();
 
   fn opt_to_flag(opt: &str) -> Option<MsFlags> {
     match opt {

--- a/crates/stage2/src/bash_compat.rs
+++ b/crates/stage2/src/bash_compat.rs
@@ -131,11 +131,26 @@ pub fn run(args: &Args) -> Result<()> {
   // anything they spawn also land in /dev/kmsg (or /run/log) - matches the
   // `exec > >(tee ...) 2>&1` block in stage-2-init.sh:110-122. The shell
   // skips this in the systemd-stage-1 path; we do the same.
-  let saved = if in_systemd_stage1 {
+  //
+  // StdioGuard restores fds 1/2 on drop, covering both the success path and
+  // any error path, so systemd always inherits a real console fd.
+  // capture_stdio spawns /bin/sh, which does not exist before the activation
+  // script runs. Treat failure as non-fatal: logging degrades but boot must
+  // not be blocked on a diagnostic feature.
+  let _stdio = StdioGuard(if in_systemd_stage1 {
     None
   } else {
-    capture_stdio(&log_dest).context("Failed to set up stdio capture")?
-  };
+    match capture_stdio(&log_dest) {
+      Ok(guard) => guard,
+      Err(e) => {
+        log_message(
+          log_dest.as_deref(),
+          &format!("stage-2-init: warning: stdio capture unavailable: {e:#}"),
+        );
+        None
+      },
+    }
+  });
 
   run_activation_script(&args.system_config, &log_dest)
     .context("Activation script failed")?;
@@ -153,12 +168,6 @@ pub fn run(args: &Args) -> Result<()> {
     "stage-2-init: activation complete, starting systemd",
   );
 
-  // Restore console fds before the exec so systemd inherits the terminal,
-  // not the tee pipe. Matches stage-2-init.sh's `exec 1>&$logOutFd` restore.
-  if let Some(saved) = saved {
-    restore_stdio(saved);
-  }
-
   Ok(())
 }
 
@@ -166,6 +175,18 @@ pub fn run(args: &Args) -> Result<()> {
 struct SavedStdio {
   stdout: RawFd,
   stderr: RawFd,
+}
+
+// Restores fds 1 and 2 on drop so error paths don't leave stdout/stderr
+// pointing at the tee pipe.
+struct StdioGuard(Option<SavedStdio>);
+
+impl Drop for StdioGuard {
+  fn drop(&mut self) {
+    if let Some(saved) = self.0.take() {
+      restore_stdio(saved);
+    }
+  }
 }
 
 /// Redirect fds 1 and 2 through a `tee`-like helper. Returns the saved

--- a/crates/stage2/src/lib.rs
+++ b/crates/stage2/src/lib.rs
@@ -131,12 +131,6 @@ fn recreate_booted_system_atomically(
 ) -> anyhow::Result<()> {
   let booted_system = Path::new("/run/booted-system");
 
-  if booted_system.exists() || booted_system.is_symlink() {
-    std::fs::remove_file(booted_system).with_context(|| {
-      format!("Failed to remove old {}", booted_system.display())
-    })?;
-  }
-
   nixos_init_compat::atomic_symlink(system_config, booted_system).with_context(
     || {
       format!(

--- a/crates/stage2/src/lib.rs
+++ b/crates/stage2/src/lib.rs
@@ -101,7 +101,7 @@ fn run_and_handoff_inner(args: &cli::Args) -> ! {
   // (IN_NIXOS_SYSTEMD_STAGE1), we must exit cleanly. Systemd's
   // initrd-switch-root service handles the switch-root and the systemd exec.
   // Exec-ing systemd from within the chroot would be wrong.
-  if std::env::var("IN_NIXOS_SYSTEMD_STAGE1").unwrap_or_default() == "true" {
+  if std::env::var("IN_NIXOS_SYSTEMD_STAGE1").is_ok_and(|var| var == "true") {
     log::info!(
       "stage-2-init: systemd initrd path; returning to initrd-switch-root"
     );

--- a/crates/stage2/src/lib.rs
+++ b/crates/stage2/src/lib.rs
@@ -3,7 +3,6 @@
 //! This library provides bash-compatible stage 2 initialization with opt-in
 //! improvements borrowed from nixos-init. It is designed to be called from
 //! the nixos-core multicall binary.
-
 use std::path::Path;
 
 use anyhow::Context;
@@ -96,7 +95,20 @@ fn run_and_handoff_inner(args: &cli::Args) -> ! {
     std::process::exit(1);
   }
 
-  log::info!("stage-2-init: activation complete, starting systemd");
+  log::info!("stage-2-init: activation complete");
+
+  // When called as prepare-root from the systemd initrd
+  // (IN_NIXOS_SYSTEMD_STAGE1), we must exit cleanly. Systemd's
+  // initrd-switch-root service handles the switch-root and the systemd exec.
+  // Exec-ing systemd from within the chroot would be wrong.
+  if std::env::var("IN_NIXOS_SYSTEMD_STAGE1").unwrap_or_default() == "true" {
+    log::info!(
+      "stage-2-init: systemd initrd path; returning to initrd-switch-root"
+    );
+    std::process::exit(0);
+  }
+
+  log::info!("stage-2-init: starting systemd");
 
   if args.use_systemctl_handoff() {
     #[cfg(feature = "systemd-integration")]

--- a/crates/update-users-groups/src/lib.rs
+++ b/crates/update-users-groups/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
   collections::{HashMap, HashSet},
   fs::{self, File, Permissions},
-  io::{BufRead, BufReader, Read, Write},
+  io::{BufRead, BufReader, Error, Write},
   os::unix::fs::{PermissionsExt, chown},
   path::Path,
 };
@@ -984,9 +984,21 @@ fn hash_password(password: &str) -> Result<String> {
   // with our own salt so the rand graph stays out.
   const CHARSET: &[u8; 64] =
     b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
   let mut raw = [0u8; 8];
-  let mut f = File::open("/dev/urandom").context("opening /dev/urandom")?;
-  f.read_exact(&mut raw).context("reading /dev/urandom")?;
+
+  // getrandom(2) reads directly from the kernel entropy pool without requiring
+  // /dev to be mounted. This is *especially* critical when running inside a
+  // chroot (e.g. the systemd-initrd prepare-root path where /dev is not yet
+  // populated.
+  let ret = unsafe {
+    libc::syscall(libc::SYS_getrandom, raw.as_mut_ptr(), raw.len(), 0u64)
+  };
+
+  if ret < 0 {
+    return Err(anyhow::anyhow!("getrandom: {}", Error::last_os_error()));
+  }
+
   let salt: String = raw
     .iter()
     .map(|b| CHARSET[(*b as usize) & 0x3F] as char)

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -298,6 +298,31 @@ in {
         };
       };
 
+      bootStage2 = {
+        enable =
+          mkEnableOption ""
+          // {
+            default = true;
+            description = ''
+              Whether to replace {option}`system.build.bootStage2` with nixos-core's
+              `stage-2-init`.
+
+              Under a systemd initrd, nixpkgs' `initrd-nixos-activation.service`
+              calls the resulting `prepare-root` via `chroot /sysroot`.
+
+              `stage-2-init` detects `IN_NIXOS_SYSTEMD_STAGE1=true` and exits
+              after activation instead of `exec`-ing systemd.
+            '';
+          };
+
+        package = mkOption {
+          type = package;
+          default = bootStage2;
+          description = "";
+          readOnly = true;
+        };
+      };
+
       initialRamdisk = {
         enable =
           mkEnableOption ""
@@ -388,14 +413,14 @@ in {
     system = {
       build = {
         # Stage 1
-        bootStage1 = mkIf cfg.components.bootStage1 (mkForce cfg.components.bootStage1.package);
+        bootStage1 = mkIf cfg.components.bootStage1.enable (mkForce cfg.components.bootStage1.package);
 
         # Rebuild the initrd with our bootStage1 as /init. This, at the cost of risking getting
         # out of sync, mirrors the contents list from nixpkgs' stage-1.nix.
         initialRamdisk = mkIf cfg.components.initialRamdisk.enable (mkForce cfg.components.initialRamdisk.package);
 
         # Stage 2
-        bootStage2 = mkIf (!config.boot.initrd.systemd.enable) (mkForce bootStage2);
+        bootStage2 = mkIf cfg.components.bootStage2.enable (mkForce cfg.components.bootStage2.package);
 
         # Bootloader Installer
         installBootLoader = mkIf cfg.components.bootloaderInstaller.enable (mkForce cfg.components.bootloaderInstaller.package);

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -151,6 +151,11 @@ self: {
         export HOST_ID=${lib.escapeShellArg config.networking.hostId}
       ''}
 
+      export DEVICE_MANAGER=udev
+      export UDEV_BINARY=${lib.escapeShellArg "${extra-utils}/bin/systemd-udevd"}
+      export UDEVADM_BINARY=${lib.escapeShellArg "${extra-utils}/bin/udevadm"}
+      export LINK_UNITS_DEST=/etc/systemd/network
+
       exec ${extra-utils}/bin/nixos-core stage-1-init
     '';
   };
@@ -175,7 +180,13 @@ self: {
         else "false"
       }
       export STAGE2_GREETING=${lib.escapeShellArg "<<< ${config.system.nixos.distroName} Stage 2 >>>"}
-      exec ${cfg.package}/bin/stage-2-init
+      ${lib.optionalString cfg.components.nixosInitCompat.enable ''
+        export FIRMWARE_PATH=${lib.escapeShellArg "${config.hardware.firmware}/lib/firmware"}
+        export MODPROBE_BINARY=${lib.escapeShellArg "${pkgs.kmod}/bin/modprobe"}
+        export ENV_BINARY=${lib.escapeShellArg config.environment.usrbinenv}
+        export SH_BINARY=${lib.escapeShellArg config.environment.binsh}
+      ''}
+      exec ${cfg.package}/bin/stage-2-init${lib.optionalString cfg.components.nixosInitCompat.enable " --setup-firmware --setup-modprobe --setup-fhs --create-current-system"}
     '';
   };
 
@@ -398,6 +409,21 @@ in {
           '';
           description = "Script contents passed to the user activation script";
         };
+      };
+
+      nixosInitCompat = {
+        enable =
+          mkEnableOption ""
+          // {
+            default = config.boot.initrd.systemd.enable;
+            defaultText = literalExpression "config.boot.initrd.systemd.enable";
+            description = ''
+              Whether to wire nixos-init-compatible setup into stage2 for the
+              systemd-initrd path. When enabled, stage2 receives flags to set up
+              `/run/current-system`, the firmware search path, the modprobe
+              binary pointer, and FHS compatibility symlinks.
+            '';
+          };
       };
     };
   };

--- a/nix/vm-tests/boot.nix
+++ b/nix/vm-tests/boot.nix
@@ -9,7 +9,25 @@ mkTest {
   nodes.machine = {
     imports = [nixosModule testCommons];
     system.nixos-core.enable = true;
-    boot.loader.grub.enable = false;
+    boot = {
+      loader.grub.enable = false;
+      # nixos-core's stage1 only runs with the scripted initrd; systemd initrd
+      # would bypass it entirely and also forbids postMountCommands.
+      initrd.systemd.enable = false;
+
+      # Canary launched during stage1's postMountCommands. After switch_root,
+      # stage1 calls kill_remaining_processes; a plain shell process (cmdline
+      # does not start with '@') must be killed. /run is moved to the new root
+      # via MS_MOVE so the pid-file survives into the booted system.
+      initrd.postMountCommands = ''
+        sh -c 'while true; do sleep 1; done' &
+        echo $! > /run/canary.pid
+        while [ ! -s /run/canary.pid ]; do sleep 0.1; done
+      '';
+
+      # Marker written by stage2's postBootCommands hook.
+      postBootCommands = "touch /etc/post-boot-ran";
+    };
     networking.hostId = "cafebabe";
   };
 
@@ -21,9 +39,22 @@ mkTest {
       machine.succeed("test -f /etc/os-release")
       machine.succeed("test -e /etc/passwd")
 
+    with subtest("stage1 kills regular initrd processes before switch_root"):
+      machine.succeed("test -s /run/canary.pid")
+      machine.fail("kill -0 $(cat /run/canary.pid) 2>/dev/null")
+
     with subtest("stage2 system symlinks point into the store"):
       machine.succeed("readlink /run/current-system | grep -q '^/nix/store/'")
       machine.succeed("readlink /run/booted-system  | grep -q '^/nix/store/'")
+      machine.succeed("test /run/current-system -ef /run/booted-system")
+
+    with subtest("nix store mount options"):
+      for opt in ["ro", "nosuid", "nodev"]:
+        machine.succeed(f'[[ "$(findmnt --direction backward --first-only --noheadings --output OPTIONS /nix/store)" =~ (^|,){opt}(,|$) ]]')
+      machine.fail("touch /nix/store/should-not-work")
+
+    with subtest("postBootCommands ran"):
+      machine.succeed("test -f /etc/post-boot-ran")
 
     with subtest("HOST_ID written as 4 native-endian bytes"):
       machine.succeed("test -f /etc/hostid")

--- a/nix/vm-tests/rebuild.nix
+++ b/nix/vm-tests/rebuild.nix
@@ -1,0 +1,49 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+mkTest ({nodes, ...}: {
+  name = "nixos-core-rebuild";
+
+  nodes.machine = {
+    imports = [nixosModule testCommons];
+    system.nixos-core.enable = true;
+    boot.loader.grub.enable = false;
+
+    specialisation.gen2.configuration = {
+      environment.etc."nixos-core-gen2-marker".text = "generation-2";
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("gen1 booted"):
+      machine.succeed("readlink /run/current-system | grep -q '^/nix/store/'")
+      machine.succeed("readlink /run/booted-system  | grep -q '^/nix/store/'")
+      machine.succeed("test /run/current-system -ef /run/booted-system")
+      machine.fail("test -f /etc/nixos-core-gen2-marker")
+
+    gen1_toplevel = machine.succeed("readlink /run/current-system").strip()
+    gen2 = "${nodes.machine.system.build.toplevel}/specialisation/gen2"
+
+    with subtest("switch to generation 2"):
+      machine.succeed(f"{gen2}/bin/switch-to-configuration switch")
+
+    with subtest("current-system changed to gen2 toplevel"):
+      gen2_toplevel = machine.succeed("readlink /run/current-system").strip()
+      assert gen2_toplevel != gen1_toplevel, \
+        f"current-system was not updated: still {gen2_toplevel}"
+      machine.succeed("readlink /run/current-system | grep -q '^/nix/store/'")
+
+    with subtest("nixos-core /etc activation applied gen2 file"):
+      machine.succeed("test -f /etc/nixos-core-gen2-marker")
+      machine.succeed("grep -qx generation-2 /etc/nixos-core-gen2-marker")
+
+    with subtest("nixos-core /etc static symlink still valid"):
+      machine.succeed("test -L /etc/static")
+      machine.succeed("readlink /etc/static | grep -q '^/nix/store/'")
+  '';
+})

--- a/nix/vm-tests/systemd-initrd.nix
+++ b/nix/vm-tests/systemd-initrd.nix
@@ -1,0 +1,57 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+mkTest {
+  name = "nixos-core-systemd-initrd";
+
+  nodes.machine = {
+    imports = [nixosModule testCommons];
+    system.nixos-core.enable = true;
+    boot = {
+      loader.grub.enable = false;
+
+      # Force systemd initrd; nixos-core's stage1 is a no-op here. Systemd basically
+      # owns all of stage1, but stage2/activation/etc components still apply.
+      initrd.systemd.enable = true;
+
+      # Marker written by stage2's postBootCommands hook.
+      postBootCommands = "touch /etc/post-boot-ran";
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("basic presence"):
+      machine.succeed("test -f /etc/os-release")
+      machine.succeed("test -e /etc/passwd")
+
+    with subtest("stage2 system symlinks point into the store"):
+      machine.succeed("readlink /run/current-system | grep -q '^/nix/store/'")
+      machine.succeed("readlink /run/booted-system  | grep -q '^/nix/store/'")
+      machine.succeed("test /run/current-system -ef /run/booted-system")
+
+    with subtest("nix store mount options"):
+      for opt in ["ro", "nosuid", "nodev"]:
+        machine.succeed(f'[[ "$(findmnt --direction backward --first-only --noheadings --output OPTIONS /nix/store)" =~ (^|,){opt}(,|$) ]]')
+      machine.fail("touch /nix/store/should-not-work")
+
+    with subtest("postBootCommands ran"):
+      machine.succeed("test -f /etc/post-boot-ran")
+
+    with subtest("nixos-core /etc activation ran"):
+      # setup-etc atomically creates /etc/static -> /nix/store/..-etc first;
+      # all other /etc symlinks are passthrough links into /etc/static.
+      machine.succeed("test -L /etc/static")
+      machine.succeed("readlink /etc/static | grep -q '^/nix/store/'")
+      machine.succeed("readlink -f /etc/os-release | grep -q '^/nix/store/'")
+
+    with subtest("nixos-core user/group activation ran"):
+      machine.succeed("test -f /etc/passwd")
+      machine.succeed("test -f /etc/shadow")
+      machine.succeed("stat -c '%a' /etc/shadow | grep -qx 640")
+  '';
+}

--- a/nix/vm-tests/systemd-initrd.nix
+++ b/nix/vm-tests/systemd-initrd.nix
@@ -3,7 +3,7 @@
   nixosModule,
   testCommons,
 }:
-mkTest {
+mkTest ({nodes, ...}: {
   name = "nixos-core-systemd-initrd";
 
   nodes.machine = {
@@ -53,5 +53,28 @@ mkTest {
       machine.succeed("test -f /etc/passwd")
       machine.succeed("test -f /etc/shadow")
       machine.succeed("stat -c '%a' /etc/shadow | grep -qx 640")
+
+    with subtest("current-system points to exact toplevel"):
+      machine.succeed(
+        "test \"$(readlink /run/current-system)\" = \"${nodes.machine.system.build.toplevel}\""
+      )
+
+    with subtest("firmware search path written"):
+      machine.succeed("test -f /sys/module/firmware_class/parameters/path")
+      machine.succeed(
+        "grep -qF /lib/firmware /sys/module/firmware_class/parameters/path"
+      )
+
+    with subtest("modprobe binary written to /proc/sys/kernel/modprobe"):
+      machine.succeed(
+        "grep -qF modprobe /proc/sys/kernel/modprobe"
+      )
+
+    with subtest("FHS compatibility symlinks present"):
+      machine.succeed("test -L /usr/bin/env")
+      machine.succeed("test -L /bin/sh")
+
+    with subtest("systemd state passing from initrd"):
+      machine.succeed("systemd-analyze | grep -q '(initrd)'")
   '';
-}
+})


### PR DESCRIPTION
CC @amaanq for testing.

Little improvements to the reliability & correctness of the early boot process in both stage1 and stage2 as well as some new test cases to ensure we can catch errors. I've caught only one, but maybe that's what Amaan was running into...

I've moved back libc's device major/minor extraction, because I think as long as libc is in scope it's the "correct" way of doing so. In the case we drop libc, it might be considered for removal again. Other than that this PR improves error handling for filesystem checks and makes stdio restoration more robust in stage2 by making its error non-fatal.

P.S. fixes a few boot issues. I don't like using libc but it seems to be the "clean" option here. For once I refuse to write C or assembly here. #bringbackrand