### PR TITLE
nix/vm-tests: guard against LD_LIBRARY_PATH leak and multi-line uid/gid maps

### DIFF
--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -7,6 +7,11 @@ self: {pkgs}: let
         documentation.enable = pkgs.lib.mkDefault false;
         # virtio_pci must be loaded explicitly so udev can discover virtio_blk.
         boot.initrd.kernelModules = ["virtio_pci" "virtio_blk"];
+
+        # The nixosTest default of 1 GiB / 1 core OOMs the backdoor shell
+        # on CI and surfaces as "Shell disconnected".
+        virtualisation.memorySize = 2048;
+        virtualisation.cores = 2;
       };
     })
     .config

--- a/nix/vm-tests/boot.nix
+++ b/nix/vm-tests/boot.nix
@@ -60,5 +60,13 @@ mkTest {
       machine.succeed("test -f /etc/hostid")
       machine.succeed("test $(wc -c < /etc/hostid) -eq 4")
       machine.succeed("od -An -tx1 /etc/hostid | tr -d ' \\n' | grep -qx 'bebafeca'")
+
+    with subtest("stage1 wipes environment before exec /init"):
+      # Upstream pivots with `exec env -i` so LD_LIBRARY_PATH=@extraUtils@/lib
+      # doesn't leak into PID 1 and break systemd's libseccomp dlopen.
+      machine.fail("tr '\\0' '\\n' < /proc/1/environ | grep -q '^LD_LIBRARY_PATH='")
+      # Without seccomp, systemd drops the service PATH that resolves
+      # relative ExecStart names, so tmpfiles-setup and friends 203/EXEC.
+      machine.succeed("test -z \"$(systemctl --failed --no-legend)\"")
   '';
 }

--- a/nix/vm-tests/users.nix
+++ b/nix/vm-tests/users.nix
@@ -147,6 +147,13 @@ in
         machine.succeed("grep -qE '^subuser:[0-9]+:65536$' /etc/subuid")
         machine.succeed("grep -qE '^subuser:[0-9]+:65536$' /etc/subgid")
 
+      with subtest("uid/gid maps written as single-line JSON"):
+        # Upstream perl's `decode_json(read_file(...))` runs in list context
+        # and only sees the first line, so pretty-printed JSON breaks any
+        # round-trip through the perl script. Match its canonical output.
+        for f in ("/var/lib/nixos/uid-map", "/var/lib/nixos/gid-map"):
+            machine.succeed(f"test $(wc -l < {f}) -le 1")
+
       with subtest("mutableUsers=false reverts external password changes"):
         machine.succeed("sed -i 's/^immutableuser:!:/immutableuser:changed:/' /etc/shadow")
         machine.succeed("grep '^immutableuser:' /etc/shadow | cut -d: -f2 | grep -qx changed")


### PR DESCRIPTION
Both regressions shipped as real boot failures before #9 landed; pin PID 1's env and the single-line map format so they can't come back.