### PR TITLE
sleek manifest based /etc setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +35,33 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base64ct"
@@ -34,12 +76,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+ "memmap2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -53,6 +131,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "clap"
@@ -93,6 +182,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +240,27 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -156,16 +299,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -176,9 +346,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
@@ -217,6 +394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +442,15 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -271,6 +469,24 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "nix"
@@ -300,10 +516,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -338,6 +590,46 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
@@ -408,6 +700,8 @@ dependencies = [
  "anyhow",
  "clap",
  "libc",
+ "serde_json",
+ "smfh-core",
  "tempfile",
 ]
 
@@ -430,6 +724,47 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs",
+ "os_str_bytes",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smfh-core"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4fcbab3bf9b86308f5783339395084885b56815e3e00301d49046941e14be8c"
+dependencies = [
+ "blake3",
+ "color-eyre",
+ "log",
+ "rand",
+ "serde",
+ "serde_json",
+ "shellexpand",
 ]
 
 [[package]]
@@ -474,10 +809,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -509,6 +914,18 @@ dependencies = [
  "serde_json",
  "sha-crypt",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,9 +754,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smfh-core"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4fcbab3bf9b86308f5783339395084885b56815e3e00301d49046941e14be8c"
+checksum = "27d4509dc4af4bf1fa98aa8cfbd5b6c34456185d5a40b15c99c850e79cb6f5de"
 dependencies = [
  "blake3",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ nix = { version = "0.31.2", features = [ "user", "fs", "process", "mount" ] }
 serde = { version = "1.0.228", features = [ "derive" ] }
 serde_json = "1.0.149"
 sha-crypt = { version = "0.6.0", default-features = false }
-smfh-core  = "1.4.0"
+smfh-core = "1.5.0"
 tempfile = "3.27.0"
 time = { version = "0.3.47", default-features = false, features = [ "parsing", "formatting", "macros" ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nix = { version = "0.31.2", features = [ "user", "fs", "process", "mount" ] }
 serde = { version = "1.0.228", features = [ "derive" ] }
 serde_json = "1.0.149"
 sha-crypt = { version = "0.6.0", default-features = false }
+smfh-core  = "1.4.0"
 tempfile = "3.27.0"
 time = { version = "0.3.47", default-features = false, features = [ "parsing", "formatting", "macros" ] }
 

--- a/crates/setup-etc/Cargo.toml
+++ b/crates/setup-etc/Cargo.toml
@@ -12,9 +12,11 @@ name = "setup_etc"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow.workspace = true
-clap.workspace   = true
-libc.workspace   = true
+anyhow.workspace    = true
+clap.workspace      = true
+libc.workspace      = true
+serde_json.workspace = true
+smfh-core.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -18,7 +18,13 @@ struct Args {
 }
 
 const ETC_STATIC: &str = "/etc/static";
-const ETC_MANIFEST: &str = "/var/lib/nixos/etc-manifest.json";
+const ETC_MANIFEST_DEFAULT: &str = "/var/lib/nixos/etc-manifest.json";
+const ETC_MANIFEST_ENV: &str = "NIXOS_CORE_STATE_DIR";
+
+fn get_etc_manifest() -> PathBuf {
+  let state_dir = std::env::var(ETC_MANIFEST_ENV).unwrap_or_else(|_| ETC_MANIFEST_DEFAULT.to_string());
+  PathBuf::from(state_dir).join("etc-manifest.json")
+}
 
 /// Apply /etc files from the given nix store path, updating /etc/static and all
 /// derived symlinks.
@@ -56,8 +62,9 @@ pub fn run(args: &[String]) -> Result<()> {
   .context("Failed to serialise manifest")?;
 
   // Step 5: Write to a sibling temp path so the rename in step 7 is atomic.
-  let manifest_path = Path::new(ETC_MANIFEST);
-  let manifest_tmp = PathBuf::from(format!("{ETC_MANIFEST}.new"));
+  let manifest_path = get_etc_manifest();
+  let manifest_tmp = PathBuf::from(format!("{}.new", manifest_path.display()));
+  fs::create_dir_all(manifest_path.parent().unwrap())?;
   fs::write(&manifest_tmp, &manifest_content)
     .context("Failed to write manifest")?;
 
@@ -71,7 +78,7 @@ pub fn run(args: &[String]) -> Result<()> {
       .map_err(|e| anyhow::anyhow!("Failed to parse manifest: {e:?}"))?;
 
     new_manifest
-      .diff(manifest_path, "", true)
+      .diff(&manifest_path, "", true)
       .map_err(|e| anyhow::anyhow!("Failed to apply manifest diff: {e:?}"))?;
 
     // Step 7: Commit the new manifest atomically.

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -30,8 +30,12 @@ pub fn run(args: &[String]) -> Result<()> {
   atomic_symlink(&etc, Path::new(ETC_STATIC))
     .context("Failed to update /etc/static symlink")?;
 
-  // Remove the legacy Perl-based state file; the smfh manifest supersedes it.
-  let _ = fs::remove_file("/etc/.clean");
+  // Migrate from the legacy Perl tracking file: delete every copied entry
+  // it lists, then remove the file. smfh's activation will recreate the
+  // ones that are still in the configuration via the manifest. Without
+  // this, stale Perl-era copied files (regular files, not symlinks) would
+  // never be cleaned up by remove_dangling_etc_symlinks below.
+  migrate_perl_clean_file(Path::new("/etc/.clean"), Path::new("/etc"));
 
   // Step 2: Remove dangling /etc symlinks that pointed into the old
   // /etc/static. Kept as a safety net during transition and for symlinks
@@ -71,11 +75,14 @@ pub fn run(args: &[String]) -> Result<()> {
       .map_err(|e| anyhow::anyhow!("Failed to apply manifest diff: {e:?}"))?;
 
     // Step 7: Commit the new manifest atomically.
-    fs::rename(&manifest_tmp, manifest_path).context("Failed to commit manifest")
+    fs::rename(&manifest_tmp, manifest_path)
+      .context("Failed to commit manifest")
   })();
 
   if let Err(ref e) = diff_result {
-    eprintln!("warning: manifest activation failed, cleaning up temp file: {e}");
+    eprintln!(
+      "warning: manifest activation failed, cleaning up temp file: {e}"
+    );
     let _ = fs::remove_file(&manifest_tmp);
   }
   diff_result?;
@@ -123,7 +130,9 @@ fn build_etc_manifest(
     // host). Perl checks the variable as truthy; match that: any non-empty
     // value means we are inside nixos-enter.
     if relative_str == "resolv.conf"
-      && !std::env::var("IN_NIXOS_ENTER").unwrap_or_default().is_empty()
+      && !std::env::var("IN_NIXOS_ENTER")
+        .unwrap_or_default()
+        .is_empty()
     {
       continue;
     }
@@ -343,6 +352,41 @@ fn file_to_json(file: &ManifestFile) -> serde_json::Value {
     v["permissions"] = serde_json::Value::String(format!("{perm:o}"));
   }
   v
+}
+
+/// Read the legacy Perl `/etc/.clean` state file (one relative path per line),
+/// delete every listed file under `etc_dir`, and remove the state file. No-op
+/// if the file does not exist. The smfh activation that follows will recreate
+/// any entries still in the configuration; entries that were dropped from the
+/// configuration stay deleted.
+fn migrate_perl_clean_file(clean_file: &Path, etc_dir: &Path) {
+  let contents = match fs::read_to_string(clean_file) {
+    Ok(s) => s,
+    Err(_) => return,
+  };
+
+  for line in contents.lines() {
+    let entry = line.trim();
+    if entry.is_empty() || entry.starts_with('/') || entry.contains("..") {
+      // Skip blank lines and anything that tries to escape /etc.
+      continue;
+    }
+    let target = etc_dir.join(entry);
+    if let Err(e) = fs::remove_file(&target)
+      && e.kind() != std::io::ErrorKind::NotFound
+    {
+      eprintln!(
+        "warning: failed to remove legacy Perl-era file {}: {e}",
+        target.display()
+      );
+    }
+  }
+
+  if let Err(e) = fs::remove_file(clean_file)
+    && e.kind() != std::io::ErrorKind::NotFound
+  {
+    eprintln!("warning: failed to remove {}: {e}", clean_file.display());
+  }
 }
 
 /// Remove any symlink inside `etc_dir` whose target starts with `/etc/static/`

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -59,7 +59,11 @@ pub fn run(args: &[String]) -> Result<()> {
   // Step 5: Write to a sibling temp path so the rename in step 7 is atomic.
   let manifest_path = get_etc_manifest();
   let manifest_tmp = PathBuf::from(format!("{}.new", manifest_path.display()));
-  fs::create_dir_all(manifest_path.parent().unwrap())?;
+  fs::create_dir_all(
+    manifest_path
+      .parent()
+      .expect("manifest path always has a parent"),
+  )?;
   fs::write(&manifest_tmp, &manifest_content)
     .context("Failed to write manifest")?;
 

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -22,7 +22,8 @@ const ETC_MANIFEST_DEFAULT: &str = "/var/lib/nixos/etc-manifest.json";
 const ETC_MANIFEST_ENV: &str = "NIXOS_CORE_STATE_DIR";
 
 fn get_etc_manifest() -> PathBuf {
-  let state_dir = std::env::var(ETC_MANIFEST_ENV).unwrap_or_else(|_| ETC_MANIFEST_DEFAULT.to_string());
+  let state_dir = std::env::var(ETC_MANIFEST_ENV)
+    .unwrap_or_else(|_| ETC_MANIFEST_DEFAULT.to_string());
   PathBuf::from(state_dir).join("etc-manifest.json")
 }
 
@@ -36,13 +37,6 @@ pub fn run(args: &[String]) -> Result<()> {
   atomic_symlink(&etc, Path::new(ETC_STATIC))
     .context("Failed to update /etc/static symlink")?;
 
-  // Migrate from the legacy Perl tracking file: delete every copied entry
-  // it lists, then remove the file. smfh's activation will recreate the
-  // ones that are still in the configuration via the manifest. Without
-  // this, stale Perl-era copied files (regular files, not symlinks) would
-  // never be cleaned up by remove_dangling_etc_symlinks below.
-  migrate_perl_clean_file(Path::new("/etc/.clean"), Path::new("/etc"));
-
   // Step 2: Remove dangling /etc symlinks that pointed into the old
   // /etc/static. Kept as a safety net during transition and for symlinks
   // created outside of the manifest.
@@ -55,7 +49,7 @@ pub fn run(args: &[String]) -> Result<()> {
   // Step 4: Serialise to JSON. permissions must be octal strings because
   // smfh-core's deserialize_octal only accepts Option<String>.
   let files_json: Vec<serde_json::Value> =
-    files.iter().map(file_to_json).collect();
+    files.iter().map(file_to_json).collect::<Result<Vec<_>>>()?;
   let manifest_content = serde_json::to_string_pretty(
     &serde_json::json!({"version": 1, "files": files_json}),
   )
@@ -94,7 +88,14 @@ pub fn run(args: &[String]) -> Result<()> {
   }
   diff_result?;
 
-  // Step 8: Ensure the /etc/NIXOS tag file exists.
+  // Step 8: Migrate from the legacy Perl tracking file: delete every copied
+  // entry it lists, then remove the file. smfh's activation above recreated
+  // any entries still in the configuration; dropped entries stay deleted.
+  // Running this after the manifest commit means a failed activation leaves
+  // the Perl-tracked files intact. The migration retries on the next run.
+  migrate_perl_clean_file(Path::new("/etc/.clean"), Path::new("/etc"));
+
+  // Step 9: Ensure the /etc/NIXOS tag file exists.
   create_nixos_tag()?;
 
   Ok(())
@@ -134,12 +135,11 @@ fn build_etc_manifest(
     let relative_str = relative.to_string_lossy();
 
     // Skip resolv.conf when running inside `nixos-enter` (bind-mounted by the
-    // host). Perl checks the variable as truthy; match that: any non-empty
-    // value means we are inside nixos-enter.
+    // host). Perl checks the variable as truthy: non-empty and not "0".
     if relative_str == "resolv.conf"
-      && !std::env::var("IN_NIXOS_ENTER")
-        .unwrap_or_default()
-        .is_empty()
+      && std::env::var("IN_NIXOS_ENTER")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
     {
       continue;
     }
@@ -352,13 +352,13 @@ fn build_etc_manifest(
 
 /// Serialise a `ManifestFile` to a JSON value, writing `permissions` as an
 /// octal string so that smfh-core's `deserialize_octal` round-trips correctly.
-fn file_to_json(file: &ManifestFile) -> serde_json::Value {
-  let mut v =
-    serde_json::to_value(file).expect("ManifestFile is always serialisable");
+fn file_to_json(file: &ManifestFile) -> Result<serde_json::Value> {
+  let mut v = serde_json::to_value(file)
+    .context("ManifestFile is always serialisable")?;
   if let Some(perm) = file.permissions {
     v["permissions"] = serde_json::Value::String(format!("{perm:o}"));
   }
-  v
+  Ok(v)
 }
 
 /// Read the legacy Perl `/etc/.clean` state file (one relative path per line),
@@ -738,7 +738,7 @@ mod tests {
       follow_symlinks:     None,
       ignore_modification: None,
     };
-    let v = file_to_json(&file);
+    let v = file_to_json(&file).unwrap();
     assert_eq!(
       v["permissions"],
       serde_json::Value::String("644".to_string())

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -30,6 +30,9 @@ pub fn run(args: &[String]) -> Result<()> {
   atomic_symlink(&etc, Path::new(ETC_STATIC))
     .context("Failed to update /etc/static symlink")?;
 
+  // Remove the legacy Perl-based state file; the smfh manifest supersedes it.
+  let _ = fs::remove_file("/etc/.clean");
+
   // Step 2: Remove dangling /etc symlinks that pointed into the old
   // /etc/static. Kept as a safety net during transition and for symlinks
   // created outside of the manifest.
@@ -54,19 +57,28 @@ pub fn run(args: &[String]) -> Result<()> {
   fs::write(&manifest_tmp, &manifest_content)
     .context("Failed to write manifest")?;
 
-  // Step 6: Load the new manifest and transition from the old one via diff.
-  // fallback=true means a missing or corrupt old manifest triggers a clean
-  // activate rather than an error.
-  let new_manifest = Manifest::read(&manifest_tmp, false)
-    .map_err(|e| anyhow::anyhow!("Failed to parse manifest: {e:?}"))?;
+  // Steps 6–7: diff and commit; clean up the temp file on any failure so we
+  // do not leave a stale .new file behind.
+  let diff_result = (|| {
+    // Step 6: Load the new manifest and transition from the old one via diff.
+    // fallback=true means a missing or corrupt old manifest triggers a clean
+    // activate rather than an error.
+    let new_manifest = Manifest::read(&manifest_tmp, false)
+      .map_err(|e| anyhow::anyhow!("Failed to parse manifest: {e:?}"))?;
 
-  new_manifest
-    .diff(manifest_path, "", true)
-    .map_err(|e| anyhow::anyhow!("Failed to apply manifest diff: {e:?}"))?;
+    new_manifest
+      .diff(manifest_path, "", true)
+      .map_err(|e| anyhow::anyhow!("Failed to apply manifest diff: {e:?}"))?;
 
-  // Step 7: Commit the new manifest atomically.
-  fs::rename(&manifest_tmp, manifest_path)
-    .context("Failed to commit manifest")?;
+    // Step 7: Commit the new manifest atomically.
+    fs::rename(&manifest_tmp, manifest_path).context("Failed to commit manifest")
+  })();
+
+  if let Err(ref e) = diff_result {
+    eprintln!("warning: manifest activation failed, cleaning up temp file: {e}");
+    let _ = fs::remove_file(&manifest_tmp);
+  }
+  diff_result?;
 
   // Step 8: Ensure the /etc/NIXOS tag file exists.
   create_nixos_tag()?;
@@ -107,9 +119,11 @@ fn build_etc_manifest(
     let target = etc_dir.join(relative);
     let relative_str = relative.to_string_lossy();
 
-    // Skip resolv.conf when running inside `nixos-enter`.
+    // Skip resolv.conf when running inside `nixos-enter` (bind-mounted by the
+    // host). Perl checks the variable as truthy; match that: any non-empty
+    // value means we are inside nixos-enter.
     if relative_str == "resolv.conf"
-      && std::env::var("IN_NIXOS_ENTER").unwrap_or_default() == "1"
+      && !std::env::var("IN_NIXOS_ENTER").unwrap_or_default().is_empty()
     {
       continue;
     }

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+  collections::HashSet,
   fs::{self, OpenOptions},
   os::unix::fs::symlink,
   path::{Path, PathBuf},
@@ -18,7 +19,7 @@ struct Args {
 }
 
 const ETC_STATIC: &str = "/etc/static";
-const ETC_MANIFEST_DEFAULT: &str = "/var/lib/nixos/etc-manifest.json";
+const ETC_MANIFEST_DEFAULT: &str = "/var/lib/nixos";
 const ETC_MANIFEST_ENV: &str = "NIXOS_CORE_STATE_DIR";
 
 fn get_etc_manifest() -> PathBuf {
@@ -88,12 +89,14 @@ pub fn run(args: &[String]) -> Result<()> {
   }
   diff_result?;
 
-  // Step 8: Migrate from the legacy Perl tracking file: delete every copied
-  // entry it lists, then remove the file. smfh's activation above recreated
-  // any entries still in the configuration; dropped entries stay deleted.
-  // Running this after the manifest commit means a failed activation leaves
-  // the Perl-tracked files intact. The migration retries on the next run.
-  migrate_perl_clean_file(Path::new("/etc/.clean"), Path::new("/etc"));
+  // Step 8: Migrate from the legacy Perl tracking file: delete every entry it
+  // lists that is no longer in the current configuration (stale copies), then
+  // remove the file itself. Entries still in the configuration were already
+  // activated by smfh above and must not be deleted. Running after the manifest
+  // commit means a failed activation leaves Perl-tracked files intact; the
+  // migration retries cleanly on the next run.
+  let kept: HashSet<PathBuf> = files.iter().map(|f| f.target.clone()).collect();
+  migrate_perl_clean_file(Path::new("/etc/.clean"), Path::new("/etc"), &kept);
 
   // Step 9: Ensure the /etc/NIXOS tag file exists.
   create_nixos_tag()?;
@@ -362,11 +365,15 @@ fn file_to_json(file: &ManifestFile) -> Result<serde_json::Value> {
 }
 
 /// Read the legacy Perl `/etc/.clean` state file (one relative path per line),
-/// delete every listed file under `etc_dir`, and remove the state file. No-op
-/// if the file does not exist. The smfh activation that follows will recreate
-/// any entries still in the configuration; entries that were dropped from the
-/// configuration stay deleted.
-fn migrate_perl_clean_file(clean_file: &Path, etc_dir: &Path) {
+/// delete every listed file under `etc_dir` that is not in `kept`, and remove
+/// the state file. No-op if the file does not exist. `kept` is the set of
+/// target paths that the new manifest owns; those entries were already
+/// activated by smfh and must not be removed.
+fn migrate_perl_clean_file(
+  clean_file: &Path,
+  etc_dir: &Path,
+  kept: &HashSet<PathBuf>,
+) {
   let contents = match fs::read_to_string(clean_file) {
     Ok(s) => s,
     Err(_) => return,
@@ -379,6 +386,9 @@ fn migrate_perl_clean_file(clean_file: &Path, etc_dir: &Path) {
       continue;
     }
     let target = etc_dir.join(entry);
+    if kept.contains(&target) {
+      continue;
+    }
     if let Err(e) = fs::remove_file(&target)
       && e.kind() != std::io::ErrorKind::NotFound
     {

--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -1,13 +1,12 @@
 use std::{
-  collections::HashSet,
-  fs::{self, File, OpenOptions, Permissions},
-  io::Write,
-  os::unix::fs::{PermissionsExt, chown, symlink},
+  fs::{self, OpenOptions},
+  os::unix::fs::symlink,
   path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use smfh_core::manifest::{File as ManifestFile, FileKind, Manifest};
 
 /// Update /etc from the current NixOS configuration
 #[derive(Parser, Debug)]
@@ -19,6 +18,7 @@ struct Args {
 }
 
 const ETC_STATIC: &str = "/etc/static";
+const ETC_MANIFEST: &str = "/var/lib/nixos/etc-manifest.json";
 
 /// Apply /etc files from the given nix store path, updating /etc/static and all
 /// derived symlinks.
@@ -31,69 +31,58 @@ pub fn run(args: &[String]) -> Result<()> {
     .context("Failed to update /etc/static symlink")?;
 
   // Step 2: Remove dangling /etc symlinks that pointed into the old
-  // /etc/static.
+  // /etc/static. Kept as a safety net during transition and for symlinks
+  // created outside of the manifest.
   remove_dangling_etc_symlinks(Path::new("/etc"))?;
 
-  // Step 3: Load the set of files that were copied (not symlinked) last time.
-  let old_copied = load_clean_list(Path::new("/etc/.clean"))?;
+  // Step 3: Walk the $etc tree and build a smfh manifest.
+  let files =
+    build_etc_manifest(&etc, Path::new("/etc"), Path::new(ETC_STATIC))?;
 
-  // Step 4: Walk the $etc tree and apply each file to /etc.
-  let mut copied: Vec<String> = Vec::new();
-  let mut created: HashSet<String> = HashSet::new();
+  // Step 4: Serialise to JSON. permissions must be octal strings because
+  // smfh-core's deserialize_octal only accepts Option<String>.
+  let files_json: Vec<serde_json::Value> =
+    files.iter().map(file_to_json).collect();
+  let manifest_content = serde_json::to_string_pretty(
+    &serde_json::json!({"version": 1, "files": files_json}),
+  )
+  .context("Failed to serialise manifest")?;
 
-  // Note: the upstream Perl script appends to /etc/.clean as it walks, then
-  // overwrites at the end. If activation crashes mid-walk the file is left
-  // with both the old entries and a partial set of new entries. We skip the
-  // appending step and only rewrite at the end via atomic_write, so the
-  // file is either the old copy or the new one - never a mix.
-  apply_etc_tree(
-    &etc,
-    Path::new("/etc"),
-    Path::new(ETC_STATIC),
-    &mut copied,
-    &mut created,
-  )?;
+  // Step 5: Write to a sibling temp path so the rename in step 7 is atomic.
+  let manifest_path = Path::new(ETC_MANIFEST);
+  let manifest_tmp = PathBuf::from(format!("{ETC_MANIFEST}.new"));
+  fs::write(&manifest_tmp, &manifest_content)
+    .context("Failed to write manifest")?;
 
-  // Step 5: Remove old copies that no longer exist in the new etc tree.
-  for relative_fn in &old_copied {
-    if created.contains(relative_fn) {
-      continue;
-    }
-    let target = Path::new("/etc").join(relative_fn);
-    eprintln!("removing obsolete /etc/{relative_fn}");
-    if let Err(e) = fs::remove_file(&target) {
-      // Not fatal: file may have already been removed.
-      eprintln!("warning: failed to remove {}: {}", target.display(), e);
-    }
-  }
+  // Step 6: Load the new manifest and transition from the old one via diff.
+  // fallback=true means a missing or corrupt old manifest triggers a clean
+  // activate rather than an error.
+  let new_manifest = Manifest::read(&manifest_tmp, false)
+    .map_err(|e| anyhow::anyhow!("Failed to parse manifest: {e:?}"))?;
 
-  // Step 6: Write the definitive /etc/.clean with all current copies, sorted.
-  copied.sort();
-  copied.dedup();
-  {
-    let mut content = String::new();
-    for entry in &copied {
-      content.push_str(entry);
-      content.push('\n');
-    }
-    atomic_write(Path::new("/etc/.clean"), content.as_bytes(), 0o644)
-      .context("Failed to write /etc/.clean")?;
-  }
+  new_manifest
+    .diff(manifest_path, "", true)
+    .map_err(|e| anyhow::anyhow!("Failed to apply manifest diff: {e:?}"))?;
 
-  // Step 7: Ensure the /etc/NIXOS tag file exists.
+  // Step 7: Commit the new manifest atomically.
+  fs::rename(&manifest_tmp, manifest_path)
+    .context("Failed to commit manifest")?;
+
+  // Step 8: Ensure the /etc/NIXOS tag file exists.
   create_nixos_tag()?;
 
   Ok(())
 }
 
-/// Walk `etc_store` (a nix store path) and apply entries to `etc_dir` (/etc).
-fn apply_etc_tree(
+/// Walk `etc_store` and build a smfh manifest describing every file that
+/// belongs under `etc_dir` (/etc). Directories are created eagerly so that
+/// smfh has valid parent paths when activating file entries.
+fn build_etc_manifest(
   etc_store: &Path,
   etc_dir: &Path,
   etc_static: &Path,
-  copied: &mut Vec<String>,
-  created: &mut HashSet<String>,
-) -> Result<()> {
+) -> Result<Vec<ManifestFile>> {
+  let mut files: Vec<ManifestFile> = Vec::new();
   // Use a manual stack to avoid recursion limits on deeply nested trees.
   let mut stack: Vec<PathBuf> = vec![etc_store.to_path_buf()];
 
@@ -116,7 +105,7 @@ fn apply_etc_tree(
 
     // Construct the target path in /etc.
     let target = etc_dir.join(relative);
-    let relative_str = relative.to_string_lossy().into_owned();
+    let relative_str = relative.to_string_lossy();
 
     // Skip resolv.conf when running inside `nixos-enter`.
     if relative_str == "resolv.conf"
@@ -138,12 +127,6 @@ fn apply_etc_tree(
       );
       continue;
     }
-
-    created.insert(relative_str.clone());
-
-    // .mode sidecar file on the store entry indicates a copied file with
-    // explicit ownership/permissions (or a direct symlink).
-    let mode_file = PathBuf::from(format!("{}.mode", current.display()));
 
     let current_is_symlink = current
       .symlink_metadata()
@@ -176,6 +159,10 @@ fn apply_etc_tree(
       }
     }
 
+    // .mode sidecar file on the store entry indicates a copied file with
+    // explicit ownership/permissions (or a direct symlink).
+    let mode_file = PathBuf::from(format!("{}.mode", current.display()));
+
     if mode_file.exists() {
       let mode_str = match fs::read_to_string(&mode_file) {
         Ok(s) => s,
@@ -199,16 +186,18 @@ fn apply_etc_tree(
             continue;
           },
         };
-        if let Err(e) = atomic_symlink(&link_target, &target) {
-          eprintln!(
-            "warning: could not create direct symlink {}: {e}",
-            target.display()
-          );
-          continue;
-        }
-        // Record in copied list; /etc/.clean gets written atomically at the
-        // end of the run rather than appended to incrementally.
-        copied.push(relative_str.clone());
+        files.push(ManifestFile {
+          source: Some(link_target),
+          target,
+          kind: FileKind::Symlink,
+          clobber: Some(true),
+          permissions: None,
+          uid: None,
+          gid: None,
+          deactivate: None,
+          follow_symlinks: None,
+          ignore_modification: None,
+        });
       } else {
         // Numeric octal mode: copy the file with explicit uid/gid/mode.
         let mode = match u32::from_str_radix(mode_str, 8) {
@@ -224,7 +213,6 @@ fn apply_etc_tree(
 
         let uid_file = PathBuf::from(format!("{}.uid", current.display()));
         let gid_file = PathBuf::from(format!("{}.gid", current.display()));
-
         let uid_str =
           fs::read_to_string(&uid_file).unwrap_or_else(|_| "0".to_string());
         let gid_str =
@@ -255,51 +243,52 @@ fn apply_etc_tree(
           },
         };
 
-        // Source is at /etc/static/<relative>.
-        let source = etc_static.join(relative);
-        let tmp = PathBuf::from(format!("{}.tmp", target.display()));
-
-        if let Err(e) = fs::copy(&source, &tmp) {
-          eprintln!(
-            "warning: failed to copy {} to {}: {e}",
-            source.display(),
-            tmp.display()
-          );
-          continue;
-        }
-        if let Err(e) = chown(&tmp, Some(uid), Some(gid)) {
-          eprintln!("warning: failed to chown {}: {e}", tmp.display());
-        }
-        if let Err(e) = fs::set_permissions(&tmp, Permissions::from_mode(mode))
-        {
-          eprintln!("warning: failed to chmod {}: {e}", tmp.display());
-        }
-        match fs::rename(&tmp, &target) {
-          Ok(()) => {
-            // Record as a copied file; /etc/.clean is rewritten atomically
-            // once the whole walk succeeds.
-            copied.push(relative_str.clone());
-          },
+        // Source is at /etc/static/<relative>. Canonicalize to the real nix
+        // store path: smfh's check_source uses symlink_metadata, which does
+        // not follow symlinks, so a symlink source fails its is_file() guard
+        // and gets silently skipped.
+        let real_source = match fs::canonicalize(etc_static.join(relative)) {
+          Ok(p) => p,
           Err(e) => {
             eprintln!(
-              "warning: failed to rename {} to {}: {e}",
-              tmp.display(),
-              target.display(),
+              "warning: failed to canonicalize source for \
+               /etc/{relative_str}: {e}"
             );
-            let _ = fs::remove_file(&tmp);
+            continue;
           },
-        }
+        };
+        files.push(ManifestFile {
+          source: Some(real_source),
+          target,
+          kind: FileKind::Copy,
+          clobber: Some(true),
+          permissions: Some(mode),
+          uid: Some(uid),
+          gid: Some(gid),
+          deactivate: None,
+          follow_symlinks: None,
+          ignore_modification: None,
+        });
       }
     } else if current_is_symlink {
       // No .mode file and the store entry is a symlink: create a /etc/static
       // passthrough symlink, which points into /etc/static/<relative>.
-      let static_target = etc_static.join(relative);
-      if let Err(e) = atomic_symlink(&static_target, &target) {
-        eprintln!(
-          "warning: could not create symlink {}: {e}",
-          target.display()
-        );
-      }
+      // follow_symlinks must be false so smfh uses path::absolute() instead of
+      // fs::canonicalize(); canonicalize() would resolve /etc/static/<relative>
+      // all the way to the nix store, breaking the indirection that lets
+      // generation switches work without touching individual /etc symlinks.
+      files.push(ManifestFile {
+        source: Some(etc_static.join(relative)),
+        target,
+        kind: FileKind::Symlink,
+        clobber: Some(true),
+        permissions: None,
+        uid: None,
+        gid: None,
+        deactivate: None,
+        follow_symlinks: Some(false),
+        ignore_modification: None,
+      });
     } else if current.is_dir() {
       // Directory: ensure it exists in /etc and descend into it.
       if let Err(e) = fs::create_dir_all(&target) {
@@ -328,7 +317,18 @@ fn apply_etc_tree(
     // also silently skips them.
   }
 
-  Ok(())
+  Ok(files)
+}
+
+/// Serialise a `ManifestFile` to a JSON value, writing `permissions` as an
+/// octal string so that smfh-core's `deserialize_octal` round-trips correctly.
+fn file_to_json(file: &ManifestFile) -> serde_json::Value {
+  let mut v =
+    serde_json::to_value(file).expect("ManifestFile is always serialisable");
+  if let Some(perm) = file.permissions {
+    v["permissions"] = serde_json::Value::String(format!("{perm:o}"));
+  }
+  v
 }
 
 /// Remove any symlink inside `etc_dir` whose target starts with `/etc/static/`
@@ -477,40 +477,6 @@ fn atomic_symlink(target: &Path, link: &Path) -> Result<()> {
   Ok(())
 }
 
-/// Atomically write `content` to `path` via a `.tmp` rename, then set `mode`.
-fn atomic_write(path: &Path, content: &[u8], mode: u32) -> Result<()> {
-  let tmp = PathBuf::from(format!("{}.tmp", path.display()));
-  {
-    let mut f = File::create(&tmp)
-      .with_context(|| format!("Failed to create {}", tmp.display()))?;
-    f.write_all(content)
-      .with_context(|| format!("Failed to write {}", tmp.display()))?;
-  }
-  fs::set_permissions(&tmp, Permissions::from_mode(mode))
-    .with_context(|| format!("Failed to chmod {}", tmp.display()))?;
-  fs::rename(&tmp, path).with_context(|| {
-    format!("Failed to rename {} to {}", tmp.display(), path.display())
-  })?;
-  Ok(())
-}
-
-/// Load the list of previously copied files from /etc/.clean.
-/// Returns an empty set if the file does not exist.
-fn load_clean_list(path: &Path) -> Result<HashSet<String>> {
-  if !path.exists() {
-    return Ok(HashSet::new());
-  }
-  let content = fs::read_to_string(path)
-    .with_context(|| format!("Failed to read {}", path.display()))?;
-  Ok(
-    content
-      .lines()
-      .filter(|l| !l.is_empty())
-      .map(str::to_string)
-      .collect(),
-  )
-}
-
 /// Read the entries of a directory, returning paths sorted by file name.
 fn read_dir_sorted(dir: &Path) -> Result<Vec<PathBuf>> {
   let mut entries: Vec<PathBuf> = fs::read_dir(dir)
@@ -539,29 +505,99 @@ mod tests {
 
   use super::*;
 
+  /// Build a minimal fake nix-store etc tree under `store_dir` and call
+  /// `build_etc_manifest`, returning the entries.
+  fn manifest_for(
+    store_dir: &Path,
+    etc_dir: &Path,
+    static_dir: &Path,
+  ) -> Vec<ManifestFile> {
+    build_etc_manifest(store_dir, etc_dir, static_dir).unwrap()
+  }
+
+  #[test]
+  fn test_build_manifest_passthrough_symlink() {
+    let dir = TempDir::new().unwrap();
+    let store = dir.path().join("store");
+    let etc = dir.path().join("etc");
+    let stat = dir.path().join("static");
+    fs::create_dir_all(&store).unwrap();
+    fs::create_dir_all(&etc).unwrap();
+    fs::create_dir_all(&stat).unwrap();
+
+    // A symlink in the store without a .mode sidecar → pass-through symlink
+    symlink("/nix/store/irrelevant", store.join("hostname")).unwrap();
+
+    let files = manifest_for(&store, &etc, &stat);
+    assert_eq!(files.len(), 1);
+    let f = &files[0];
+    assert_eq!(f.kind, FileKind::Symlink);
+    assert_eq!(f.target, etc.join("hostname"));
+    assert_eq!(f.source, Some(stat.join("hostname")));
+    // Must not canonicalize so the symlink points at /etc/static, not the
+    // store.
+    assert_eq!(f.follow_symlinks, Some(false));
+  }
+
+  #[test]
+  fn test_build_manifest_direct_symlink() {
+    let dir = TempDir::new().unwrap();
+    let store = dir.path().join("store");
+    let etc = dir.path().join("etc");
+    let stat = dir.path().join("static");
+    fs::create_dir_all(&store).unwrap();
+    fs::create_dir_all(&etc).unwrap();
+    fs::create_dir_all(&stat).unwrap();
+
+    let nix_target = PathBuf::from("/nix/store/aaaa-foo/bin/sh");
+    symlink(&nix_target, store.join("shells")).unwrap();
+    fs::write(store.join("shells.mode"), "direct-symlink").unwrap();
+
+    let files = manifest_for(&store, &etc, &stat);
+    assert_eq!(files.len(), 1);
+    let f = &files[0];
+    assert_eq!(f.kind, FileKind::Symlink);
+    assert_eq!(f.source, Some(nix_target));
+    assert_eq!(f.target, etc.join("shells"));
+  }
+
+  #[test]
+  fn test_build_manifest_copied_file() {
+    let dir = TempDir::new().unwrap();
+    let store = dir.path().join("store");
+    let etc = dir.path().join("etc");
+    let stat = dir.path().join("static");
+    fs::create_dir_all(&store).unwrap();
+    fs::create_dir_all(&etc).unwrap();
+    fs::create_dir_all(&stat).unwrap();
+
+    // The store entry drives mode detection; the static entry is the file
+    // that gets canonicalized into the manifest source.
+    fs::write(store.join("secret"), "sensitive").unwrap();
+    fs::write(store.join("secret.mode"), "0600").unwrap();
+    fs::write(stat.join("secret"), "sensitive").unwrap();
+    // No .uid/.gid files → both default to 0
+
+    let files = manifest_for(&store, &etc, &stat);
+    assert_eq!(files.len(), 1);
+    let f = &files[0];
+    assert_eq!(f.kind, FileKind::Copy);
+    assert_eq!(f.permissions, Some(0o600));
+    assert_eq!(f.uid, Some(0));
+    assert_eq!(f.gid, Some(0));
+    // Canonicalized, so the source is the real file, not a symlink.
+    assert_eq!(
+      f.source,
+      Some(fs::canonicalize(stat.join("secret")).unwrap())
+    );
+    assert_eq!(f.target, etc.join("secret"));
+  }
+
   #[test]
   fn test_resolve_id_numeric() {
     assert_eq!(resolve_id("1000", true).unwrap(), 1000);
     assert_eq!(resolve_id("+1000", true).unwrap(), 1000);
     assert_eq!(resolve_id("0", false).unwrap(), 0);
-  }
-
-  #[test]
-  fn test_load_clean_list_nonexistent() {
-    let result = load_clean_list(Path::new("/nonexistent/etc/.clean")).unwrap();
-    assert!(result.is_empty());
-  }
-
-  #[test]
-  fn test_load_clean_list_reads_lines() {
-    let dir = TempDir::new().unwrap();
-    let clean = dir.path().join(".clean");
-    fs::write(&clean, "foo\nbar\nbaz\n").unwrap();
-    let result = load_clean_list(&clean).unwrap();
-    assert!(result.contains("foo"));
-    assert!(result.contains("bar"));
-    assert!(result.contains("baz"));
-    assert_eq!(result.len(), 3);
   }
 
   #[test]
@@ -586,14 +622,6 @@ mod tests {
     atomic_symlink(&target1, &link).unwrap();
     atomic_symlink(&target2, &link).unwrap();
     assert_eq!(fs::read_link(&link).unwrap(), target2);
-  }
-
-  #[test]
-  fn test_atomic_write_creates_file() {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("out.txt");
-    atomic_write(&path, b"hello\n", 0o644).unwrap();
-    assert_eq!(fs::read_to_string(&path).unwrap(), "hello\n");
   }
 
   #[test]
@@ -629,5 +657,26 @@ mod tests {
     let file = dir.path().join("regular");
     fs::write(&file, "content").unwrap();
     assert!(!is_fully_static(&file, &static_dir));
+  }
+
+  #[test]
+  fn test_file_to_json_permissions_are_octal_string() {
+    let file = ManifestFile {
+      source:              Some(PathBuf::from("/src/foo")),
+      target:              PathBuf::from("/etc/foo"),
+      kind:                FileKind::Copy,
+      clobber:             Some(true),
+      permissions:         Some(0o644),
+      uid:                 Some(0),
+      gid:                 Some(0),
+      deactivate:          None,
+      follow_symlinks:     None,
+      ignore_modification: None,
+    };
+    let v = file_to_json(&file);
+    assert_eq!(
+      v["permissions"],
+      serde_json::Value::String("644".to_string())
+    );
   }
 }

--- a/crates/update-users-groups/src/lib.rs
+++ b/crates/update-users-groups/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
   fs::{self, File, Permissions},
   io::{BufRead, BufReader, Error, Write},
   os::unix::fs::{PermissionsExt, chown},
-  path::Path,
+  path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail};
@@ -19,11 +19,27 @@ unsafe extern "C" {
   fn getpwuid(uid: u32) -> *mut libc::passwd;
 }
 
-const UID_MAP_FILE: &str = "/var/lib/nixos/uid-map";
-const GID_MAP_FILE: &str = "/var/lib/nixos/gid-map";
-const DECL_USERS_FILE: &str = "/var/lib/nixos/declarative-users";
-const DECL_GROUPS_FILE: &str = "/var/lib/nixos/declarative-groups";
-const SUBUID_MAP_FILE: &str = "/var/lib/nixos/auto-subuid-map";
+fn get_state_dir() -> PathBuf {
+  let state_dir = std::env::var("NIXOS_CORE_STATE_DIR")
+    .unwrap_or_else(|_| "/var/lib/nixos".to_string());
+  PathBuf::from(state_dir)
+}
+
+fn uid_map_path(state_dir: &Path) -> PathBuf {
+  state_dir.join("uid-map")
+}
+fn gid_map_path(state_dir: &Path) -> PathBuf {
+  state_dir.join("gid-map")
+}
+fn decl_users_path(state_dir: &Path) -> PathBuf {
+  state_dir.join("declarative-users")
+}
+fn decl_groups_path(state_dir: &Path) -> PathBuf {
+  state_dir.join("declarative-groups")
+}
+fn subuid_map_path(state_dir: &Path) -> PathBuf {
+  state_dir.join("auto-subuid-map")
+}
 
 const SYSTEM_UID_MIN: u32 = 400;
 const SYSTEM_UID_MAX: u32 = 999;
@@ -137,16 +153,23 @@ pub fn run(args: &[String]) -> Result<()> {
   let is_dry = args.dry_activate
     || std::env::var("NIXOS_ACTION").unwrap_or_default() == "dry-activate";
 
+  let state_dir = get_state_dir();
+
   if !is_dry {
-    fs::create_dir_all("/var/lib/nixos")?;
+    fs::create_dir_all(&state_dir)?;
   }
 
-  let mut uid_map: HashMap<String, u32> = load_json_file(UID_MAP_FILE)?;
-  let mut gid_map: HashMap<String, u32> = load_json_file(GID_MAP_FILE)?;
-  let mut sub_uid_map: HashMap<String, u32> = load_json_file(SUBUID_MAP_FILE)?;
+  let mut uid_map: HashMap<String, u32> =
+    load_json_file(&uid_map_path(&state_dir).display().to_string())?;
+  let mut gid_map: HashMap<String, u32> =
+    load_json_file(&gid_map_path(&state_dir).display().to_string())?;
+  let mut sub_uid_map: HashMap<String, u32> =
+    load_json_file(&subuid_map_path(&state_dir).display().to_string())?;
 
-  let decl_users = load_declarative_list(DECL_USERS_FILE)?;
-  let decl_groups = load_declarative_list(DECL_GROUPS_FILE)?;
+  let decl_users =
+    load_declarative_list(&decl_users_path(&state_dir).display().to_string())?;
+  let decl_groups =
+    load_declarative_list(&decl_groups_path(&state_dir).display().to_string())?;
 
   let spec_content = fs::read_to_string(&args.spec_file)
     .with_context(|| format!("Failed to read spec file: {}", args.spec_file))?;
@@ -250,7 +273,7 @@ pub fn run(args: &[String]) -> Result<()> {
     let mut names: Vec<&String> = groups_out.keys().collect();
     names.sort();
     update_file(
-      DECL_GROUPS_FILE,
+      &decl_groups_path(&state_dir).display().to_string(),
       &names
         .iter()
         .map(|s| s.as_str())
@@ -293,7 +316,11 @@ pub fn run(args: &[String]) -> Result<()> {
     update_file_lines("/etc/group", &lines, 0o644, is_dry)?;
   }
 
-  update_file_json_map(GID_MAP_FILE, &gid_map, is_dry)?;
+  update_file_json_map(
+    &gid_map_path(&state_dir).display().to_string(),
+    &gid_map,
+    is_dry,
+  )?;
 
   nscd_invalidate("group", is_dry);
 
@@ -462,7 +489,7 @@ pub fn run(args: &[String]) -> Result<()> {
     let mut names: Vec<&String> = users_out.keys().collect();
     names.sort();
     update_file(
-      DECL_USERS_FILE,
+      &decl_users_path(&state_dir).display().to_string(),
       &names
         .iter()
         .map(|s| s.as_str())
@@ -510,7 +537,11 @@ pub fn run(args: &[String]) -> Result<()> {
     update_file_lines("/etc/passwd", &lines, 0o644, is_dry)?;
   }
 
-  update_file_json_map(UID_MAP_FILE, &uid_map, is_dry)?;
+  update_file_json_map(
+    &uid_map_path(&state_dir).display().to_string(),
+    &uid_map,
+    is_dry,
+  )?;
 
   nscd_invalidate("passwd", is_dry);
 
@@ -678,7 +709,11 @@ pub fn run(args: &[String]) -> Result<()> {
 
   update_file_lines("/etc/subuid", &sub_uids, 0o644, is_dry)?;
   update_file_lines("/etc/subgid", &sub_gids, 0o644, is_dry)?;
-  update_file_json_map(SUBUID_MAP_FILE, &sub_uid_map, is_dry)?;
+  update_file_json_map(
+    &subuid_map_path(&state_dir).display().to_string(),
+    &sub_uid_map,
+    is_dry,
+  )?;
 
   Ok(())
 }

--- a/docs/etc.md
+++ b/docs/etc.md
@@ -1,0 +1,123 @@
+# `/etc` activation
+
+The `setup-etc` crate, exposed as `nixos-core setup-etc`, or `setup-etc`
+directly when symlinked from the `nixos-core` binary, replaces upstream
+`setup-etc.pl` Perl script that Nixpkgs uses to pupulate `/etc` from the current
+NixOS generation.
+
+The two implementations agree on the on-disk shape of `/etc`. This is the same
+`/etc/static` indirection, the same pass-through symlinks, the same
+`direct-symlink` mode, the same copied files with explicit `mode`/`uid`/`gid`
+sidecars, however, the way they track and apply changes is different.
+
+## How it works
+
+[smfh]: https://github.com/feel-co/smfh
+
+1. Atomically swap `/etc/static` to point at the new generation's etc tree.
+2. Replay the legacy `/etc/.clean` file written by the Perl script: every
+   relative path it lists is removed from `/etc`, then `.clean` itself is
+   removed. The smfh activation in step 5 will recreate any of those entries
+   that are still in the configuration; entries that have been dropped from the
+   configuration stay deleted. One-shot per system.
+3. Walk `/etc` and remove any symlink whose target lives under `/etc/static/`
+   but whose entry no longer exists in the new generation. Mirrors the Perl
+   `cleanup` pass and protects against symlinks created by an earlier activation
+   that are not in our manifest.
+4. Walk the generation's etc store tree and build an [smfh] manifest describing
+   every entry: pass-through symlinks (`/etc/foo` -> `/etc/static/foo`), direct
+   symlinks (`/etc/foo` -> `/nix/store/...`), and copied files (with explicit
+   `mode`, `uid`, `gid`).
+5. Write the manifest to `/var/lib/nixos/etc-manifest.json.new`, ask smfh to
+   diff it against the existing `/var/lib/nixos/etc-manifest.json`, and apply
+   the diff: deactivate (delete) entries that disappeared, activate entries that
+   appeared, and atomically re-apply entries whose source changed.
+6. Atomically rename the temp manifest into place.
+7. Touch `/etc/NIXOS`.
+
+> [!INFO]
+> The manifest at `/var/lib/nixos/etc-manifest.json` is the source of truth for
+> what nixos-core has written into `/etc`. It supersedes the Perl script's
+> `/etc/.clean` state file, which only tracked copied files.
+
+## Differences from the Perl script
+
+As of the instroduction of `smfh` into `nixos-core`, we do `/etc` setup a little
+differently. The differences are specifically in the tracking and activation
+models.
+
+### Tracking Model
+
+Previously the **Perl-based** setup wrote `/etc/.clean` listing the relative
+paths of files it had copied. Pass-through symlinks were not tracked there; they
+were cleaned up on the next activation by walking `/etc` and removing any
+symlink under `/etc/static/` that no longer existed in the new generation.
+
+**nixos-core**, however, writes `/var/lib/nixos/etc-manifest.json`, which lists
+_every entry_. This includes symlinks, direct symlinks, copies and the like.
+Cleanup of stale entries is driven by an explicit diff between the old and new
+manifest, not by a heuristic walk of `/etc`. The dangling-symlink walk is still
+done as a safety net for entries that originated from outside the manifest (e.g.
+a previous Perl-based activation, or external tooling).
+
+The first activation under nixos-core has no prior manifest, so smfh falls back
+to a full activation. The dangling-symlink walk handles the cleanup of entries
+left over from the previous Perl run.
+
+### Activation atomicity
+
+Both implementations use a temp-file + rename when replacing an existing entry,
+so the common case (system updates) keeps `/etc/foo` either fully old or fully
+new. Files are _never_ half-written. Though, the implementations diverge on
+**first activation** of a copied file (the target does not yet exist). I.e.,
+**setup-etc.pl** copies into `$target.tmp`, sets ownership and mode on the temp
+file, and then renames into place. The final path never exists with wrong
+permissions. **nixos-core** (via smfh), on another hand, writes directly to the
+final path on first activation, then calls `chmod`/`chown`. There is a brief
+window during which the file exists at its final path with default umask
+permissions (typically `0644`) before the configured mode is applied.
+
+This window only exists on the very first time a given path is activated. Once
+the file is present, every subsequent activation uses the atomic temp-and-rename
+path. In practice, the regression is mostly theoretical for NixOS: `/etc/shadow`
+is managed by `update-users-groups`, not by `environment.etc` with a `mode`
+sidecar, and most `mode`-bearing entries are not secret material. Future
+versions of smfh may close this window upstream.
+
+### Idempotent re-runs
+
+`nixos-core` also leverages smfh's manifest and BLAKE3 hash systems to verify
+each file (hash for copies, target check for symlinks) and skips entries that
+already match. The net effect of this behaviour is faster idempotent activations
+and no needless rewrites of `/etc` files. User edits to copied entries are still
+overwritten on the next generation switch (entries are flagged `clobber: true`),
+matching Perl's behavior in spirit. This is rather different as opposed to the
+`setup-etc.pl` script that unconditionally re-copied every copied file on every
+activation, whether the source changed or not.
+
+## Migrating from the Perl script
+
+There's, well, nothing for you to do. The first activation under nixos-core
+rplays `/etc/.clean` to delete every copied file the Perl script tracked, then
+removes the file itself; entries still in the configuration are recreated by the
+manifest activation that follows. `nixos-core` uses the dangling-symlink walk to
+clean up any pass-through symlinks left over from the previous Perl run that are
+no longer in the configuration, and writes a fresh
+`/var/lib/nixos/etc-manifest.json`.
+
+After the first activation, all subsequent activations are diff-driven from the
+manifest. The VM tests for the `setup-etc` module exercise this path end-to-end
+on its `perl` node: boot under `setup-etc.pl`, switch to nixos-core, verify that
+both stale symlinks and stale copied files from the Perl run are removed. If you
+notice any issues, create an issue!
+
+## Glossary/Files
+
+- `/etc/NIXOS` - tag file marking this filesystem as a NixOS root.
+- `/etc/static` - symlink to the current generation's etc store tree.
+- `/var/lib/nixos/etc-manifest.json` - current manifest. Do not edit manually;
+  setup-etc rewrites it on every activation.
+- `/var/lib/nixos/etc-manifest.json.new` - temp file used for the atomic rename.
+  Removed automatically on success or failure; if it exists outside an
+  in-progress activation, the previous activation crashed mid-write and it is
+  safe to delete.

--- a/docs/etc.md
+++ b/docs/etc.md
@@ -15,28 +15,29 @@ sidecars, however, the way they track and apply changes is different.
 [smfh]: https://github.com/feel-co/smfh
 
 1. Atomically swap `/etc/static` to point at the new generation's etc tree.
-2. Replay the legacy `/etc/.clean` file written by the Perl script: every
-   relative path it lists is removed from `/etc`, then `.clean` itself is
-   removed. The smfh activation in step 5 will recreate any of those entries
-   that are still in the configuration; entries that have been dropped from the
-   configuration stay deleted. One-shot per system.
-3. Walk `/etc` and remove any symlink whose target lives under `/etc/static/`
+2. Walk `/etc` and remove any symlink whose target lives under `/etc/static/`
    but whose entry no longer exists in the new generation. Mirrors the Perl
    `cleanup` pass and protects against symlinks created by an earlier activation
    that are not in our manifest.
-4. Walk the generation's etc store tree and build an [smfh] manifest describing
+3. Walk the generation's etc store tree and build an [smfh] manifest describing
    every entry: pass-through symlinks (`/etc/foo` -> `/etc/static/foo`), direct
    symlinks (`/etc/foo` -> `/nix/store/...`), and copied files (with explicit
    `mode`, `uid`, `gid`).
-5. Write the manifest to `/var/lib/nixos/etc-manifest.json.new`, ask smfh to
-   diff it against the existing `/var/lib/nixos/etc-manifest.json`, and apply
+4. Write the manifest to `$NIXOS_CORE_STATE_DIR/etc-manifest.json.new`, ask smfh to
+   diff it against the existing `$NIXOS_CORE_STATE_DIR/etc-manifest.json`, and apply
    the diff: deactivate (delete) entries that disappeared, activate entries that
    appeared, and atomically re-apply entries whose source changed.
-6. Atomically rename the temp manifest into place.
+5. Atomically rename the temp manifest into place.
+6. Replay the legacy `/etc/.clean` file written by the Perl script: every
+   relative path it lists is removed from `/etc`, then `.clean` itself is
+   removed. Entries still in the configuration were already recreated by smfh
+   in step 4; entries dropped from the configuration stay deleted. One-shot per
+   system. Running after the manifest commit means a failed activation leaves
+   the Perl-tracked files intact so the migration retries cleanly.
 7. Touch `/etc/NIXOS`.
 
-> [!INFO]
-> The manifest at `/var/lib/nixos/etc-manifest.json` is the source of truth for
+> [!NOTE]
+> The manifest at `$NIXOS_CORE_STATE_DIR/etc-manifest.json` is the source of truth for
 > what nixos-core has written into `/etc`. It supersedes the Perl script's
 > `/etc/.clean` state file, which only tracked copied files.
 
@@ -53,7 +54,7 @@ paths of files it had copied. Pass-through symlinks were not tracked there; they
 were cleaned up on the next activation by walking `/etc` and removing any
 symlink under `/etc/static/` that no longer existed in the new generation.
 
-**nixos-core**, however, writes `/var/lib/nixos/etc-manifest.json`, which lists
+**nixos-core**, however, writes `$NIXOS_CORE_STATE_DIR/etc-manifest.json`, which lists
 _every entry_. This includes symlinks, direct symlinks, copies and the like.
 Cleanup of stale entries is driven by an explicit diff between the old and new
 manifest, not by a heuristic walk of `/etc`. The dangling-symlink walk is still
@@ -98,12 +99,12 @@ activation, whether the source changed or not.
 ## Migrating from the Perl script
 
 There's, well, nothing for you to do. The first activation under nixos-core
-rplays `/etc/.clean` to delete every copied file the Perl script tracked, then
-removes the file itself; entries still in the configuration are recreated by the
-manifest activation that follows. `nixos-core` uses the dangling-symlink walk to
+replays `/etc/.clean` to delete every copied file the Perl script tracked, then
+removes the file itself; entries still in the configuration were already recreated
+by the manifest activation. `nixos-core` uses the dangling-symlink walk to
 clean up any pass-through symlinks left over from the previous Perl run that are
 no longer in the configuration, and writes a fresh
-`/var/lib/nixos/etc-manifest.json`.
+`$NIXOS_CORE_STATE_DIR/etc-manifest.json`.
 
 After the first activation, all subsequent activations are diff-driven from the
 manifest. The VM tests for the `setup-etc` module exercise this path end-to-end
@@ -111,13 +112,20 @@ on its `perl` node: boot under `setup-etc.pl`, switch to nixos-core, verify that
 both stale symlinks and stale copied files from the Perl run are removed. If you
 notice any issues, create an issue!
 
+## State Directory
+
+The state directory is controlled by the `NIXOS_CORE_STATE_DIR` environment
+variable, falling back to `/var/lib/nixos` for backward compatibility. This
+allows nixos-core to work on NixOS variants that do not use the `/var/lib/nixos`
+path.
+
 ## Glossary/Files
 
 - `/etc/NIXOS` - tag file marking this filesystem as a NixOS root.
 - `/etc/static` - symlink to the current generation's etc store tree.
-- `/var/lib/nixos/etc-manifest.json` - current manifest. Do not edit manually;
-  setup-etc rewrites it on every activation.
-- `/var/lib/nixos/etc-manifest.json.new` - temp file used for the atomic rename.
+- `$NIXOS_CORE_STATE_DIR/etc-manifest.json` - current manifest. Do not edit manually;
+  setup-etc rewrites it on every activation. Defaults to `/var/lib/nixos/etc-manifest.json`.
+- `$NIXOS_CORE_STATE_DIR/etc-manifest.json.new` - temp file used for the atomic rename.
   Removed automatically on success or failure; if it exists outside an
   in-progress activation, the previous activation crashed mid-write and it is
   safe to delete.

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -270,6 +270,17 @@ in {
     enable = mkEnableOption "nixos-core multi-call binary";
     package = mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} ["nixos-core"] {};
 
+    stateDir = mkOption {
+      type = lib.types.str;
+      default = "/var/lib/nixos";
+      example = "/run/nixos";
+      description = ''
+        Directory used by nixos-core to store runtime state (etc manifest,
+        uid/gid maps, etc.). Exported as {env}`NIXOS_CORE_STATE_DIR` to activation
+        scripts. Override on NixOS variants that use a different state path.
+      '';
+    };
+
     # Resurface some of the hard-coded checks so that the user can selectively override
     # behaviour in non-standard environments. This is deliberately *not* named `settings`
     # to leave room for a future settings option in case we decide to set that up.
@@ -289,7 +300,7 @@ in {
             default = !config.boot.initrd.systemd.enable;
             defaultText = literalExpression "!config.boot.initrd.systemd.enable";
             description = ''
-              Whether to create {option} `system.build.bootStage1` wrapper with `nixos-core` available.
+              Whether to create {option}`system.build.bootStage1` wrapper with `nixos-core` available.
 
               ::: {.note}
 
@@ -385,6 +396,7 @@ in {
           type = lines;
           default = ''
             echo "setting up /etc..."
+            export NIXOS_CORE_STATE_DIR=${lib.escapeShellArg cfg.stateDir}
             ${lib.getExe' cfg.package "setup-etc"} ${config.system.build.etc}/etc
           '';
           description = "Script contents passed to {option}`system.build.etcActivationCommands`";
@@ -405,6 +417,7 @@ in {
           default = ''
             install -m 0700 -d /root
             install -m 0755 -d /home
+            export NIXOS_CORE_STATE_DIR=${lib.escapeShellArg cfg.stateDir}
             ${lib.getExe' cfg.package "update-users-groups"} ${usersSpec}
           '';
           description = "Script contents passed to the user activation script";

--- a/nix/vm-tests/etc.nix
+++ b/nix/vm-tests/etc.nix
@@ -54,8 +54,9 @@ mkTest ({nodes, ...}: {
       system.nixos-core.enable = true;
       boot.loader.grub.enable = false;
 
-      # Use a custom state directory to verify NIXOS_CORE_STATE_DIR works.
-      environment.variables.NIXOS_CORE_STATE_DIR = "/var/lib/custom-nixos";
+      # Use a custom state directory to verify the stateDir option is exported
+      # correctly. environment.variables is not sourced by activation scripts.
+      system.nixos-core.stateDir = "/var/lib/custom-nixos";
 
       environment.etc = {
         "custom-state-marker".text = "custom-state-works";
@@ -113,10 +114,10 @@ mkTest ({nodes, ...}: {
     perl.wait_for_unit("multi-user.target")
 
     with subtest("custom state directory respects NIXOS_CORE_STATE_DIR"):
-      custom_state.succeed("test -f /var/lib/custom-nixos/etc-manifest.json")
-      custom_state.succeed("grep -q custom-state-marker /var/lib/custom-nixos/etc-manifest.json")
-      custom_state.succeed("grep -q custom-state-secret /var/lib/custom-nixos/etc-manifest.json")
-      custom_state.succeed("test ! -f /var/lib/nixos/etc-manifest.json")
+      state.succeed("test -f /var/lib/custom-nixos/etc-manifest.json")
+      state.succeed("grep -q custom-state-marker /var/lib/custom-nixos/etc-manifest.json")
+      state.succeed("grep -q custom-state-secret /var/lib/custom-nixos/etc-manifest.json")
+      state.succeed("test ! -f /var/lib/nixos/etc-manifest.json")
 
     with subtest("text entry symlinked through /etc/static"):
       machine.succeed("grep -qx nixos-core-works /etc/nixos-core-marker")

--- a/nix/vm-tests/etc.nix
+++ b/nix/vm-tests/etc.nix
@@ -55,13 +55,20 @@ mkTest {
       machine.succeed("readlink /etc/nixos-core-direct | grep -qv /etc/static")
 
     with subtest("infrastructure files written"):
-      machine.succeed("test -f /etc/.clean")
+      machine.succeed("test -f /var/lib/nixos/etc-manifest.json")
       machine.succeed("test -f /etc/NIXOS")
+
+    with subtest("manifest contains expected entries"):
+      machine.succeed("grep -q nixos-core-marker /var/lib/nixos/etc-manifest.json")
+      machine.succeed("grep -q nixos-core-secret /var/lib/nixos/etc-manifest.json")
+      machine.succeed("grep -q nixos-core-source /var/lib/nixos/etc-manifest.json")
+      machine.succeed("grep -q nixos-core-direct /var/lib/nixos/etc-manifest.json")
 
     with subtest("idempotent re-activation"):
       machine.execute("/run/current-system/activate")
       machine.succeed("grep -qx nixos-core-works /etc/nixos-core-marker")
       machine.succeed("grep -qx sensitive /etc/nixos-core-secret")
       machine.succeed("stat -c '%a' /etc/nixos-core-secret | grep -qx 600")
+      machine.succeed("test -f /var/lib/nixos/etc-manifest.json")
   '';
 }

--- a/nix/vm-tests/etc.nix
+++ b/nix/vm-tests/etc.nix
@@ -7,90 +7,116 @@
 }:
 mkTest ({nodes, ...}: {
   name = "nixos-core-etc";
+  nodes = {
+    # Two nodes:
+    #
+    # - `machine` boots straight under nixos-core's setup-etc and exercises
+    #   pass-through symlinks, copied files, source entries, direct symlinks,
+    #   and idempotent re-activation.
+    #
+    # - `perl` boots under upstream's setup-etc.pl (nixos-core's etc activation
+    #   disabled), then switches into a specialisation that re-enables
+    #   nixos-core's setup-etc. Verifies the Perl-to-nixos-core migration:
+    #   /etc/.clean is replayed, stale entries are dropped, surviving entries
+    #   are preserved.
+    #
+    # TODO: see if we can do reboot subtests. As far as I understand vm tests run
+    # with `boot.loader.grub.enable = false`, so a `shutdown` + `start` cycle
+    # reboots the disk image into the same oplevel the test was built with. So
+    # i the end there is no bootloader to redirect into the post-switch generation.
+    # The boot test covers a fresh nixos-core boot end-to-end, which is the best
+    # I can do :/
+    machine = {
+      imports = [nixosModule testCommons];
+      system.nixos-core.enable = true;
+      boot.loader.grub.enable = false;
 
-  # Two nodes:
-  #
-  # - `machine` boots straight under nixos-core's setup-etc and exercises
-  #   pass-through symlinks, copied files, source entries, direct symlinks,
-  #   and idempotent re-activation.
-  #
-  # - `perl` boots under upstream's setup-etc.pl (nixos-core's etc activation
-  #   disabled), then switches into a specialisation that re-enables
-  #   nixos-core's setup-etc. Verifies the Perl-to-nixos-core migration:
-  #   /etc/.clean is replayed, stale entries are dropped, surviving entries
-  #   are preserved.
-  #
-  # TODO: see if we can do reboot subtests. As far as I understand vm tests run
-  # with `boot.loader.grub.enable = false`, so a `shutdown` + `start` cycle
-  # reboots the disk image into the same oplevel the test was built with. So
-  # i the end there is no bootloader to redirect into the post-switch generation.
-  # The boot test covers a fresh nixos-core boot end-to-end, which is the best
-  # I can do :/
-  nodes.machine = {
-    imports = [nixosModule testCommons];
-    system.nixos-core.enable = true;
-    boot.loader.grub.enable = false;
+      environment.etc = {
+        "nixos-core-marker".text = "nixos-core-works";
 
-    environment.etc = {
-      "nixos-core-marker".text = "nixos-core-works";
+        "nixos-core-secret" = {
+          text = "sensitive";
+          mode = "0600";
+        };
 
-      "nixos-core-secret" = {
-        text = "sensitive";
-        mode = "0600";
-      };
+        "nixos-core-source".source = writeText "etc-source" "from-source";
 
-      "nixos-core-source".source = writeText "etc-source" "from-source";
-
-      "nixos-core-direct" = {
-        source = writeText "etc-direct" "direct-content";
-        mode = "direct-symlink";
-      };
-    };
-  };
-
-  nodes.perl = {
-    imports = [nixosModule testCommons];
-
-    # Bare `false` wins over the option's default (priority 1500) without
-    # using mkForce, so the specialisation can mkForce true cleanly.
-    system.nixos-core.enable = true;
-    system.nixos-core.components.etcActivation.enable = false;
-    boot.loader.grub.enable = false;
-
-    environment.etc = {
-      "perl-migration-marker".text = "from-perl";
-
-      "perl-migration-secret" = {
-        text = "secret-content";
-        mode = "0600";
-      };
-
-      "perl-migration-direct" = {
-        source = writeText "perl-migration-direct-src" "direct-from-perl";
-        mode = "direct-symlink";
-      };
-
-      # Stale entries: present in the Perl-managed gen, dropped in the
-      # nixos-core specialisation. The migration must remove both.
-      "perl-migration-stale-symlink".text = "stale-symlink";
-
-      "perl-migration-stale-copy" = {
-        text = "stale-copy";
-        mode = "0640";
+        "nixos-core-direct" = {
+          source = writeText "etc-direct" "direct-content";
+          mode = "direct-symlink";
+        };
       };
     };
 
-    specialisation.nixos-core-etc.configuration = {
-      system.nixos-core.components.etcActivation.enable = lib.mkForce true;
-      environment.etc."perl-migration-stale-symlink".enable = lib.mkForce false;
-      environment.etc."perl-migration-stale-copy".enable = lib.mkForce false;
+    # State machine. Ha ha.
+    state = {
+      imports = [nixosModule testCommons];
+      system.nixos-core.enable = true;
+      boot.loader.grub.enable = false;
+
+      # Use a custom state directory to verify NIXOS_CORE_STATE_DIR works.
+      environment.variables.NIXOS_CORE_STATE_DIR = "/var/lib/custom-nixos";
+
+      environment.etc = {
+        "custom-state-marker".text = "custom-state-works";
+        "custom-state-secret" = {
+          text = "custom-secret";
+          mode = "0600";
+        };
+      };
+    };
+
+    perl = {
+      imports = [nixosModule testCommons];
+
+      # Bare `false` wins over the option's default (priority 1500) without
+      # using mkForce, so the specialisation can mkForce true cleanly.
+      system.nixos-core.enable = true;
+      system.nixos-core.components.etcActivation.enable = false;
+      boot.loader.grub.enable = false;
+
+      environment.etc = {
+        "perl-migration-marker".text = "from-perl";
+
+        "perl-migration-secret" = {
+          text = "secret-content";
+          mode = "0600";
+        };
+
+        "perl-migration-direct" = {
+          source = writeText "perl-migration-direct-src" "direct-from-perl";
+          mode = "direct-symlink";
+        };
+
+        # Stale entries: present in the Perl-managed gen, dropped in the
+        # nixos-core specialisation. The migration must remove both.
+        "perl-migration-stale-symlink".text = "stale-symlink";
+
+        "perl-migration-stale-copy" = {
+          text = "stale-copy";
+          mode = "0640";
+        };
+      };
+
+      specialisation.nixos-core-etc.configuration = {
+        system.nixos-core.components.etcActivation.enable = lib.mkForce true;
+        environment.etc."perl-migration-stale-symlink".enable = lib.mkForce false;
+        environment.etc."perl-migration-stale-copy".enable = lib.mkForce false;
+      };
     };
   };
 
   testScript = ''
     start_all()
     machine.wait_for_unit("multi-user.target")
+    state.wait_for_unit("multi-user.target")
     perl.wait_for_unit("multi-user.target")
+
+    with subtest("custom state directory respects NIXOS_CORE_STATE_DIR"):
+      custom_state.succeed("test -f /var/lib/custom-nixos/etc-manifest.json")
+      custom_state.succeed("grep -q custom-state-marker /var/lib/custom-nixos/etc-manifest.json")
+      custom_state.succeed("grep -q custom-state-secret /var/lib/custom-nixos/etc-manifest.json")
+      custom_state.succeed("test ! -f /var/lib/nixos/etc-manifest.json")
 
     with subtest("text entry symlinked through /etc/static"):
       machine.succeed("grep -qx nixos-core-works /etc/nixos-core-marker")

--- a/nix/vm-tests/etc.nix
+++ b/nix/vm-tests/etc.nix
@@ -1,12 +1,31 @@
 {
+  lib,
   mkTest,
   nixosModule,
   testCommons,
   writeText,
 }:
-mkTest {
+mkTest ({nodes, ...}: {
   name = "nixos-core-etc";
 
+  # Two nodes:
+  #
+  # - `machine` boots straight under nixos-core's setup-etc and exercises
+  #   pass-through symlinks, copied files, source entries, direct symlinks,
+  #   and idempotent re-activation.
+  #
+  # - `perl` boots under upstream's setup-etc.pl (nixos-core's etc activation
+  #   disabled), then switches into a specialisation that re-enables
+  #   nixos-core's setup-etc. Verifies the Perl-to-nixos-core migration:
+  #   /etc/.clean is replayed, stale entries are dropped, surviving entries
+  #   are preserved.
+  #
+  # TODO: see if we can do reboot subtests. As far as I understand vm tests run
+  # with `boot.loader.grub.enable = false`, so a `shutdown` + `start` cycle
+  # reboots the disk image into the same oplevel the test was built with. So
+  # i the end there is no bootloader to redirect into the post-switch generation.
+  # The boot test covers a fresh nixos-core boot end-to-end, which is the best
+  # I can do :/
   nodes.machine = {
     imports = [nixosModule testCommons];
     system.nixos-core.enable = true;
@@ -29,9 +48,49 @@ mkTest {
     };
   };
 
+  nodes.perl = {
+    imports = [nixosModule testCommons];
+
+    # Bare `false` wins over the option's default (priority 1500) without
+    # using mkForce, so the specialisation can mkForce true cleanly.
+    system.nixos-core.enable = true;
+    system.nixos-core.components.etcActivation.enable = false;
+    boot.loader.grub.enable = false;
+
+    environment.etc = {
+      "perl-migration-marker".text = "from-perl";
+
+      "perl-migration-secret" = {
+        text = "secret-content";
+        mode = "0600";
+      };
+
+      "perl-migration-direct" = {
+        source = writeText "perl-migration-direct-src" "direct-from-perl";
+        mode = "direct-symlink";
+      };
+
+      # Stale entries: present in the Perl-managed gen, dropped in the
+      # nixos-core specialisation. The migration must remove both.
+      "perl-migration-stale-symlink".text = "stale-symlink";
+
+      "perl-migration-stale-copy" = {
+        text = "stale-copy";
+        mode = "0640";
+      };
+    };
+
+    specialisation.nixos-core-etc.configuration = {
+      system.nixos-core.components.etcActivation.enable = lib.mkForce true;
+      environment.etc."perl-migration-stale-symlink".enable = lib.mkForce false;
+      environment.etc."perl-migration-stale-copy".enable = lib.mkForce false;
+    };
+  };
+
   testScript = ''
-    machine.start()
+    start_all()
     machine.wait_for_unit("multi-user.target")
+    perl.wait_for_unit("multi-user.target")
 
     with subtest("text entry symlinked through /etc/static"):
       machine.succeed("grep -qx nixos-core-works /etc/nixos-core-marker")
@@ -70,5 +129,76 @@ mkTest {
       machine.succeed("grep -qx sensitive /etc/nixos-core-secret")
       machine.succeed("stat -c '%a' /etc/nixos-core-secret | grep -qx 600")
       machine.succeed("test -f /var/lib/nixos/etc-manifest.json")
+
+    ## Perl-to-nixos-core migration
+    with subtest("Perl-based activation populated /etc"):
+      perl.succeed("test -f /etc/.clean")
+      perl.fail("test -e /var/lib/nixos/etc-manifest.json")
+      perl.succeed("grep -q perl-migration-secret /etc/.clean")
+      perl.succeed("grep -q perl-migration-stale-copy /etc/.clean")
+
+    with subtest("pass-through symlink under Perl"):
+      perl.succeed("grep -qx from-perl /etc/perl-migration-marker")
+      perl.succeed("test -L /etc/perl-migration-marker")
+      perl.succeed(
+        "readlink /etc/perl-migration-marker | grep -qx /etc/static/perl-migration-marker"
+      )
+
+    with subtest("copied file under Perl"):
+      perl.succeed("grep -qx secret-content /etc/perl-migration-secret")
+      perl.succeed("test ! -L /etc/perl-migration-secret")
+      perl.succeed("stat -c '%a' /etc/perl-migration-secret | grep -qx 600")
+
+    with subtest("direct symlink under Perl"):
+      perl.succeed("grep -qx direct-from-perl /etc/perl-migration-direct")
+      perl.succeed("test -L /etc/perl-migration-direct")
+      perl.succeed("readlink /etc/perl-migration-direct | grep -q '^/nix/store/'")
+
+    with subtest("stale entries present under Perl"):
+      perl.succeed("test -e /etc/perl-migration-stale-symlink")
+      perl.succeed("test -e /etc/perl-migration-stale-copy")
+
+    nixos_core = "${nodes.perl.system.build.toplevel}/specialisation/nixos-core-etc"
+
+    with subtest("switch to nixos-core's setup-etc"):
+      perl.succeed(f"{nixos_core}/bin/switch-to-configuration switch")
+
+    with subtest("Perl state file removed, manifest written"):
+      perl.fail("test -e /etc/.clean")
+      perl.succeed("test -f /var/lib/nixos/etc-manifest.json")
+
+    with subtest("pass-through symlink survives migration"):
+      perl.succeed("grep -qx from-perl /etc/perl-migration-marker")
+      perl.succeed("test -L /etc/perl-migration-marker")
+      perl.succeed(
+        "readlink /etc/perl-migration-marker | grep -qx /etc/static/perl-migration-marker"
+      )
+
+    with subtest("copied file survives migration with mode preserved"):
+      perl.succeed("grep -qx secret-content /etc/perl-migration-secret")
+      perl.succeed("test ! -L /etc/perl-migration-secret")
+      perl.succeed("stat -c '%a' /etc/perl-migration-secret | grep -qx 600")
+
+    with subtest("direct symlink survives migration"):
+      perl.succeed("grep -qx direct-from-perl /etc/perl-migration-direct")
+      perl.succeed("test -L /etc/perl-migration-direct")
+      perl.succeed("readlink /etc/perl-migration-direct | grep -q '^/nix/store/'")
+
+    with subtest("stale Perl-era entries removed after migration"):
+      perl.fail("test -e /etc/perl-migration-stale-symlink")
+      perl.fail("test -e /etc/perl-migration-stale-copy")
+
+    with subtest("manifest mentions migrated entries"):
+      perl.succeed("grep -q perl-migration-marker /var/lib/nixos/etc-manifest.json")
+      perl.succeed("grep -q perl-migration-secret /var/lib/nixos/etc-manifest.json")
+      perl.succeed("grep -q perl-migration-direct /var/lib/nixos/etc-manifest.json")
+
+    with subtest("idempotent re-activation under nixos-core"):
+      perl.execute("/run/current-system/activate")
+      perl.fail("test -e /etc/.clean")
+      perl.succeed("test -f /var/lib/nixos/etc-manifest.json")
+      perl.succeed("grep -qx from-perl /etc/perl-migration-marker")
+      perl.succeed("grep -qx secret-content /etc/perl-migration-secret")
+      perl.succeed("stat -c '%a' /etc/perl-migration-secret | grep -qx 600")
   '';
-}
+})

--- a/nix/vm-tests/rebuild.nix
+++ b/nix/vm-tests/rebuild.nix
@@ -1,7 +1,9 @@
 {
+  lib,
   mkTest,
   nixosModule,
   testCommons,
+  writeText,
 }:
 mkTest ({nodes, ...}: {
   name = "nixos-core-rebuild";
@@ -11,7 +13,24 @@ mkTest ({nodes, ...}: {
     system.nixos-core.enable = true;
     boot.loader.grub.enable = false;
 
+    environment.etc = {
+      # A plain text entry present in gen1 only; used to verify stale-entry
+      # removal when switching forward to gen2.
+      "nixos-core-gen1-marker".text = "generation-1";
+
+      # A direct-symlink entry in gen1; must also be cleaned up on gen switch.
+      "nixos-core-gen1-direct" = {
+        source = writeText "gen1-direct-content" "gen1-direct";
+        mode = "direct-symlink";
+      };
+    };
+
     specialisation.gen2.configuration = {
+      # Specialisations merge with the base config, so we must explicitly
+      # disable the gen1-only entries so they are absent from the gen2 etc
+      # store derivation and therefore removed by the manifest diff.
+      environment.etc."nixos-core-gen1-marker".enable = lib.mkForce false;
+      environment.etc."nixos-core-gen1-direct".enable = lib.mkForce false;
       environment.etc."nixos-core-gen2-marker".text = "generation-2";
     };
   };
@@ -24,6 +43,7 @@ mkTest ({nodes, ...}: {
       machine.succeed("readlink /run/current-system | grep -q '^/nix/store/'")
       machine.succeed("readlink /run/booted-system  | grep -q '^/nix/store/'")
       machine.succeed("test /run/current-system -ef /run/booted-system")
+      machine.succeed("grep -qx generation-1 /etc/nixos-core-gen1-marker")
       machine.fail("test -f /etc/nixos-core-gen2-marker")
 
     gen1_toplevel = machine.succeed("readlink /run/current-system").strip()
@@ -45,5 +65,24 @@ mkTest ({nodes, ...}: {
     with subtest("nixos-core /etc static symlink still valid"):
       machine.succeed("test -L /etc/static")
       machine.succeed("readlink /etc/static | grep -q '^/nix/store/'")
+
+    with subtest("gen1-only entries removed after forward switch"):
+      # The manifest diff must have deactivated files absent from gen2.
+      machine.fail("test -e /etc/nixos-core-gen1-marker")
+      machine.fail("test -e /etc/nixos-core-gen1-direct")
+
+    with subtest("rollback to generation 1"):
+      machine.succeed(f"{gen1_toplevel}/bin/switch-to-configuration switch")
+
+    with subtest("current-system rolled back to gen1 toplevel"):
+      rolled_back = machine.succeed("readlink /run/current-system").strip()
+      assert rolled_back == gen1_toplevel, \
+        f"rollback did not restore gen1: got {rolled_back}"
+
+    with subtest("gen2-only entry removed after rollback"):
+      machine.fail("test -e /etc/nixos-core-gen2-marker")
+
+    with subtest("gen1 entries restored after rollback"):
+      machine.succeed("grep -qx generation-1 /etc/nixos-core-gen1-marker")
   '';
 })


### PR DESCRIPTION
Refactors the `/etc` activation logic to use a manifest-based approach via the `smfh-core` library, replacing the legacy `.clean` file mechanism. I've previously  [migrated smfh to a library-first design](https://github.com/feel-co/smfh/pull/39), which is now available on [crates.io](https://crates.io) as `smfh-core`. This new design lets us use the manifest-based design of smfh and its linking logic instead. Thus, the new implementation builds a manifest of `/etc` files, serializes it to JSON, and applies changes atomically and idempotently. This is, in my opinion, a great win for the reliability, maintainability and testabiltiy of `/etc` management.

Speaking of tests, we've got new tests. Much more actually, because I wanted to verify compatibility with the old Perl script as well. Adds a *bunch* of new tests to verify `/etc` setup works as expected.