### PR TITLE
stage1: mount bcachefs via the `mount.bcachefs` helper

### DIFF
--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
   io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
   os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt, symlink},
   path::{Path, PathBuf},
-  process::Command,
+  process::{Command, ExitStatus, Stdio},
   thread,
   time::{Duration, Instant},
 };
@@ -963,13 +963,22 @@ fn mount_filesystem(fs_info: &FsInfo) -> Result<()> {
 
   // Handle special filesystem types
   match fs_info.fstype.as_str() {
-    "zfs" | "bcachefs" => {
-      // These are handled specially - they may already be mounted
+    "zfs" => {
+      // Mounted by the ZFS userspace tools.
       log_message(
         &format!("Skipping mount of {} (handled by kernel)", fs_info.fstype),
         true,
       );
       return Ok(());
+    },
+    "bcachefs" => {
+      // Mounted by the `mount.bcachefs` helper.
+      return mount_bcachefs(
+        &fs_info.device,
+        &fs_info.mountpoint,
+        &fs_info.options,
+        None,
+      );
     },
     "bind" => {
       // Bind mount
@@ -1037,6 +1046,89 @@ fn mount_filesystem(fs_info: &FsInfo) -> Result<()> {
   Ok(())
 }
 
+/// Invoke `mount.bcachefs <device> <mountpoint> [-o opts]`, retrying until
+/// `wait_timeout` on non-zero exits (where [`None`] = single attempt).
+fn mount_bcachefs(
+  device: &str,
+  mountpoint: &Path,
+  options: &[String],
+  wait_timeout: Option<Duration>,
+) -> Result<()> {
+  fs::create_dir_all(mountpoint)
+    .with_context(|| format!("Failed to create mountpoint: {mountpoint:?}"))?;
+
+  log_message(
+    &format!("Mounting bcachefs {device} at {mountpoint:?}"),
+    true,
+  );
+
+  let filtered_opts = options
+    .iter()
+    .map(String::as_str)
+    .filter(|o| !o.starts_with("x-") && !o.is_empty())
+    .collect::<Vec<_>>();
+
+  let run = || -> Result<(ExitStatus, String)> {
+    let mut cmd = Command::new("mount.bcachefs");
+    if !filtered_opts.is_empty() {
+      cmd.arg("-o").arg(filtered_opts.join(","));
+    }
+    cmd.arg(device).arg(mountpoint);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let out = cmd.output().context("Failed to spawn mount.bcachefs")?;
+    let mut combined = String::from_utf8_lossy(&out.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    if !stdout.is_empty() {
+      if !combined.is_empty() {
+        combined.push('\n');
+      }
+      combined.push_str(&stdout);
+    }
+    Ok((out.status, combined.trim().to_string()))
+  };
+
+  let log_output = |output: &str| {
+    for line in output.lines() {
+      log_message(&format!("mount.bcachefs: {line}"), true);
+    }
+  };
+
+  let Some(timeout) = wait_timeout else {
+    let (status, output) = run()?;
+    if !status.success() {
+      log_output(&output);
+      bail!("mount.bcachefs {device} {mountpoint:?} exited with {status}");
+    }
+    return Ok(());
+  };
+
+  let start = Instant::now();
+  loop {
+    let (status, output) = run()?;
+    if status.success() {
+      return Ok(());
+    }
+    if start.elapsed() >= timeout {
+      log_output(&output);
+      bail!(
+        "mount.bcachefs {device} {mountpoint:?} failed after {:?}: last exit \
+         {}",
+        timeout,
+        status
+      );
+    }
+    log_message(
+      &format!(
+        "mount.bcachefs {device} not ready (exit {status}), retrying..."
+      ),
+      true,
+    );
+    log_output(&output);
+    thread::sleep(Duration::from_millis(500));
+  }
+}
+
 fn mount_root(
   cmdline: &KernelCmdline,
   target_root: &Path,
@@ -1045,18 +1137,18 @@ fn mount_root(
 ) -> Result<()> {
   log_message("Mounting root filesystem...", true);
 
-  // Prefer root= from cmdline; fall back to the "/" entry in fsInfo.
+  // fsInfo's "/" entry carries fstype/options, so read it even when `root=` is
+  // set on the cmdline, so we can still detect bcachefs below.
+  let fsinfo_root = fs_infos.iter().find(|f| f.mountpoint == Path::new("/"));
+
   let (root_device_owned, fsinfo_fstype): (String, Option<String>) =
     if let Some(r) = cmdline.root.as_ref() {
-      (r.clone(), None)
+      (r.clone(), fsinfo_root.map(|e| e.fstype.clone()))
     } else {
-      let entry = fs_infos
-        .iter()
-        .find(|f| f.mountpoint == Path::new("/"))
-        .context(
-          "No root= parameter specified on kernel command line and no '/' \
-           entry in fsInfo",
-        )?;
+      let entry = fsinfo_root.context(
+        "No root= parameter specified on kernel command line and no '/' entry \
+         in fsInfo",
+      )?;
       (entry.device.clone(), Some(entry.fstype.clone()))
     };
   let root_device = &root_device_owned;
@@ -1107,6 +1199,39 @@ fn mount_root(
       Some(cifs_opts),
     )
     .context("Failed to mount CIFS root")?;
+    return Ok(());
+  }
+
+  // In bcachefs, the filesystem UUID is fs-level, and not partition-level, so
+  // `/dev/disk/by-uuid/<uuid>` may never appear and multi-device paths never
+  // appear. Skip the udev-symlink wait and hand off to `mount.bcachefs`.
+  let early_fstype = cmdline
+    .get("rootfstype")
+    .cloned()
+    .or_else(|| fsinfo_fstype.clone());
+  if early_fstype.as_deref() == Some("bcachefs") {
+    let mut mount_opts: Vec<String> = cmdline
+      .get("rootflags")
+      .map(|s| s.split(',').map(String::from).collect())
+      .unwrap_or_default();
+    if let Some(e) = fsinfo_root {
+      for opt in &e.options {
+        if !mount_opts.contains(opt) {
+          mount_opts.push(opt.clone());
+        }
+      }
+    }
+    if !mount_opts.iter().any(|o| o == "ro" || o == "rw") {
+      mount_opts.push("rw".to_string());
+    }
+    dm.retrigger_block();
+    mount_bcachefs(
+      root_device,
+      target_root,
+      &mount_opts,
+      Some(Duration::from_secs(30)),
+    )?;
+    log_message(&format!("Root filesystem mounted at {target_root:?}"), true);
     return Ok(());
   }
 

--- a/nix/vm-tests/bcachefs-root.nix
+++ b/nix/vm-tests/bcachefs-root.nix
@@ -1,0 +1,89 @@
+{
+  mkTest,
+  nixosModule,
+  ...
+}:
+let
+  # This is pinned so `bcachefs format --uuid=...` and fileSystems."/".device agree at eval time.
+  bcachefsUuid = "fef71188-998b-4a00-a263-6b525fe9832b";
+in
+mkTest {
+  name = "nixos-core-bcachefs-root";
+
+  nodes.machine = {
+    imports = [ nixosModule ];
+    system.nixos-core.enable = true;
+    system.stateVersion = "26.05";
+
+    boot = {
+      loader.grub.enable = false;
+      initrd.systemd.enable = false;
+      supportedFilesystems = [ "bcachefs" ];
+
+      initrd.postDeviceCommands = ''
+        if ! bcachefs show-super /dev/vdb >/dev/null 2>&1; then
+          bcachefs format --force \
+            --uuid=${bcachefsUuid} \
+            --metadata_replicas 2 \
+            --label=ssd /dev/vdb \
+            --label=hdd /dev/vdc
+        fi
+      '';
+    };
+
+    virtualisation = {
+      # Otherwise qemu-vm.nix synthesises an ext4 "/" on /dev/vda that
+      # collides with our bcachefs root below.
+      useDefaultFilesystems = false;
+      emptyDiskImages = [
+        1024
+        1024
+      ];
+      fileSystems."/" = {
+        device = "UUID=${bcachefsUuid}";
+        fsType = "bcachefs";
+        neededForBoot = true;
+        options = [ "noatime" ];
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("/ is bcachefs"):
+      fstype = machine.succeed("findmnt -n -o FSTYPE /").strip()
+      assert fstype == "bcachefs", f"got {fstype!r}"
+
+    with subtest("root UUID matches config"):
+      uuid = machine.succeed(
+        "bcachefs show-super /dev/vdb | awk '/External UUID/ {print $3}'"
+      ).strip()
+      assert uuid == "${bcachefsUuid}", f"got {uuid!r}"
+
+    with subtest("both members attached"):
+      usage = machine.succeed("bcachefs fs usage /")
+      for dev in ["vdb", "vdc"]:
+        assert dev in usage, f"{dev} missing:\n{usage}"
+
+    with subtest("noatime applied"):
+      opts = machine.succeed("findmnt -n -o OPTIONS /").strip()
+      assert "noatime" in opts, f"options: {opts!r}"
+
+    with subtest("root is writable"):
+      machine.succeed("touch /root-marker && test -f /root-marker")
+
+    with subtest("/etc activation ran"):
+      machine.succeed("test -L /etc/static")
+      machine.succeed("readlink /etc/static | grep -q '^/nix/store/'")
+
+    with subtest("existing bcachefs root remounts across reboot"):
+      machine.shutdown()
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+      fstype = machine.succeed("findmnt -n -o FSTYPE /").strip()
+      assert fstype == "bcachefs"
+      machine.succeed("test -f /root-marker")
+  '';
+}

--- a/nix/vm-tests/bcachefs.nix
+++ b/nix/vm-tests/bcachefs.nix
@@ -1,0 +1,86 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+mkTest {
+  name = "nixos-core-bcachefs";
+
+  nodes.machine = {
+    imports = [
+      nixosModule
+      testCommons
+    ];
+    system.nixos-core.enable = true;
+
+    boot = {
+      loader.grub.enable = false;
+      initrd.systemd.enable = false;
+      supportedFilesystems = [ "bcachefs" ];
+
+      initrd.postDeviceCommands = ''
+        if ! bcachefs show-super /dev/vdb >/dev/null 2>&1; then
+          bcachefs format --force --metadata_replicas 2 \
+            --label=ssd /dev/vdb \
+            --label=hdd /dev/vdc
+        fi
+      '';
+    };
+
+    virtualisation.emptyDiskImages = [
+      1024
+      1024
+    ];
+
+    # qemu-vm.nix replaces `fileSystems` via mkVMOverride, meaning a plain
+    # fileSystems entry gets dropped. As such, we mount it via virtualisation.
+    virtualisation.fileSystems."/mnt/bcache" = {
+      device = "/dev/vdb:/dev/vdc";
+      fsType = "bcachefs";
+      neededForBoot = true;
+      options = [ "noatime" ];
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("mount.bcachefs is in extraUtils"):
+      machine.succeed("test -x /run/current-system/sw/bin/mount.bcachefs")
+
+    with subtest("/mnt/bcache mounted as bcachefs"):
+      machine.succeed("mountpoint -q /mnt/bcache")
+      fstype = machine.succeed("findmnt -n -o FSTYPE /mnt/bcache").strip()
+      assert fstype == "bcachefs", f"expected bcachefs, got {fstype!r}"
+
+    with subtest("both members attached"):
+      # mount(2) would have only taken the first device in the colon list.
+      usage = machine.succeed("bcachefs fs usage /mnt/bcache")
+      for dev in ["vdb", "vdc"]:
+        assert dev in usage, f"{dev} missing:\n{usage}"
+
+    with subtest("noatime forwarded"):
+      opts = machine.succeed("findmnt -n -o OPTIONS /mnt/bcache").strip()
+      assert "noatime" in opts, f"options: {opts!r}"
+
+    with subtest("mount.bcachefs accepts UUID= (what mount_root passes)"):
+      uuid = machine.succeed(
+        "bcachefs show-super /dev/vdb | awk '/External UUID/ {print $3}'"
+      ).strip()
+      machine.succeed("umount /mnt/bcache")
+      machine.succeed(f"mount.bcachefs -o noatime,rw 'UUID={uuid}' /mnt/bcache")
+      machine.succeed("mountpoint -q /mnt/bcache")
+      usage = machine.succeed("bcachefs fs usage /mnt/bcache")
+      for dev in ["vdb", "vdc"]:
+        assert dev in usage
+
+    with subtest("existing multi-device bcachefs remounts across reboot"):
+      machine.succeed("touch /mnt/bcache/marker")
+      machine.shutdown()
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("mountpoint -q /mnt/bcache")
+      machine.succeed("test -f /mnt/bcache/marker")
+  '';
+}


### PR DESCRIPTION
The raw `mount(2)` syscall can't mount multi-device bcachefs; it needs
the `mount.bcachefs` userspace helper. `mount_filesystem` now routes
bcachefs to the helper instead of silently skipping. `mount_root` does
the same through `mount_bcachefs`, which reads fstype from `fsInfo` and
skips the `/dev/disk/by-uuid/<uuid>` wait, since a filesystem-level UUID may
not have that symlink, and a multi-device path never does.