### PR TITLE
stage1: preserve moved special mounts

### DIFF
--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -2095,6 +2095,20 @@ fn parse_mount_options<'a>(
   (flags, data_str)
 }
 
+fn special_mount_target(target_root: &Path, mountpoint: &str) -> PathBuf {
+  let absolute = Path::new(mountpoint);
+
+  // These roots are MS_MOVE'd into the final root, so child mounts have to live
+  // under the initrd mount tree or they will be hidden after switch_root.
+  for moved_root in ["/dev", "/proc", "/sys", "/run"].map(Path::new) {
+    if absolute.starts_with(moved_root) {
+      return absolute.to_path_buf();
+    }
+  }
+
+  target_root.join(mountpoint.strip_prefix('/').unwrap_or(mountpoint))
+}
+
 /// Main entry point for stage 1 initialization
 pub fn run(args: &[String]) -> Result<()> {
   // Mount /proc early so KernelCmdline::parse() can read /proc/cmdline.
@@ -2258,9 +2272,16 @@ pub fn run(args: &[String]) -> Result<()> {
       let options = &args[2];
       let fstype = &args[3];
 
-      let target = config
-        .target_root
-        .join(mountpoint.strip_prefix('/').unwrap_or(mountpoint));
+      let target = special_mount_target(&config.target_root, mountpoint);
+      if is_mounted(&target) {
+        log_message(
+          &format!(
+            "Skipping specialMount {mountpoint}: {target:?} is already mounted"
+          ),
+          true,
+        );
+        continue;
+      }
       fs::create_dir_all(&target)?;
 
       let (flags, data) = parse_mount_options(options.split(','));

--- a/nix/vm-tests/specialfs.nix
+++ b/nix/vm-tests/specialfs.nix
@@ -1,0 +1,40 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+mkTest {
+  name = "nixos-core-specialfs";
+
+  nodes.machine = {
+    imports = [
+      nixosModule
+      testCommons
+    ];
+    system.nixos-core.enable = true;
+
+    boot = {
+      loader.grub.enable = false;
+      initrd.systemd.enable = false;
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("/run/keys survives switch_root as its own ramfs mount"):
+      machine.succeed("mountpoint -q /run/keys")
+      fstype = machine.succeed("findmnt -n -o FSTYPE /run/keys").strip()
+      assert fstype == "ramfs", f"expected /run/keys on ramfs, got {fstype!r}"
+
+    with subtest("activation specialfs remounts did not fail"):
+      machine.succeed("/run/current-system/activate")
+      machine.fail(
+        "journalctl -b --no-pager | grep -F 'mount point not mounted or bad option'"
+      )
+      machine.fail(
+        "journalctl -b --no-pager | grep -F 'Activation script exited with code'"
+      )
+  '';
+}


### PR DESCRIPTION
Mount special filesystems below `/dev`, `/proc`, `/sys`, and `/run` in the `initrd`
namespace, since those roots are moved into the final root during `switch_root`.
This keeps `/run/keys` visible to later activation runs, so specialfs remounts
do not fail after boot.