### PR TITLE
modules/nixos: default package to caller `pkgs.callPackage`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,13 +14,20 @@
       default = self.nixosModules.nixos-core;
     };
 
+    overlays = {
+      nixos-core = final: _prev: {
+        nixos-core = final.callPackage ./nix/package.nix {};
+      };
+      default = self.overlays.nixos-core;
+    };
+
     checks = forEachSystem (system: let
       pkgs = pkgsForEach system;
     in
       import ./nix/checks self {inherit pkgs;});
 
     packages = forEachSystem (system: {
-      nixos-core = (pkgsForEach system).callPackage ./nix/package.nix {};
+      inherit ((pkgsForEach system).extend self.overlays.default) nixos-core;
       default = self.packages.${system}.nixos-core;
     });
 

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -8,6 +8,9 @@ self: {
   inherit (lib.options) mkOption mkEnableOption mkPackageOption literalExpression;
   inherit (lib.types) package lines;
 
+  # Keep the default package on the caller's pkgs, including cross stdenvs.
+  pkgsWithOverlay = pkgs.extend self.overlays.nixos-core;
+
   udev = config.systemd.package;
   extra-utils = config.system.build.extraUtils;
   useHostResolvConf = config.networking.resolvconf.enable && config.networking.useHostResolvConf;
@@ -268,7 +271,9 @@ self: {
 in {
   options.system.nixos-core = {
     enable = mkEnableOption "nixos-core multi-call binary";
-    package = mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} ["nixos-core"] {};
+    package = mkPackageOption pkgsWithOverlay "nixos-core" {
+      pkgsText = "pkgs.extend nixos-core.overlays.nixos-core";
+    };
 
     stateDir = mkOption {
       type = lib.types.str;


### PR DESCRIPTION
The flake package default bypassed the importing module system and selected
a fresh native package set for the host platform. That made cross builds
fall back to native target builds instead of using the cross stdenv already
in scope.

Calling the in-tree package with the caller pkgs keeps native hosts unchanged
while making cross-compiled systems pick up the expected stdenv and overlays.