### PR TITLE
stage-1: centralize mount policy

### DIFF
--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -7,18 +7,29 @@ on:
     branches: [main]
 
 jobs:
+  discover:
+    name: Discover tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - id: list
+        run: |
+          tests=$(nix eval --json .#checks.x86_64-linux --apply builtins.attrNames)
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+
   vm-tests:
     name: VM Tests
+    needs: discover
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        test: [boot, etc, users]
+        test: ${{ fromJson(needs.discover.outputs.tests) }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-
+      - uses: cachix/install-nix-action@v31
       - name: Build ${{ matrix.test }} test
         run: nix build .#checks.x86_64-linux.${{ matrix.test }} -Lv

--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -373,6 +373,60 @@ impl<'a> Mount<'a> {
       .unwrap_or(false)
   }
 
+  fn is_bind_mount(&self) -> bool {
+    self.fstype == Some("bind")
+      || self
+        .options
+        .raw
+        .iter()
+        .any(|opt| opt == "bind" || opt == "rbind")
+  }
+
+  fn apply_filesystem(&self, dm: &DeviceManager) -> Result<()> {
+    match self.fstype {
+      Some("zfs") => {
+        log_message(
+          &format!(
+            "Skipping mount of {} (handled by kernel)",
+            self.fstype.unwrap_or("auto")
+          ),
+          true,
+        );
+        return Ok(());
+      },
+      Some("bcachefs") => {
+        for component in self.source.split(':') {
+          wait_for_device(component, 30, dm).ok();
+        }
+        return mount_bcachefs(
+          self.source,
+          self.target,
+          &self.options.raw,
+          Some(Duration::from_secs(30)),
+        );
+      },
+      Some("bind") => {
+        self.mount_bind().with_context(|| {
+          format!("Failed to bind mount {} to {:?}", self.source, self.target)
+        })?;
+      },
+      Some("overlay") => {
+        self.mount_overlay().with_context(|| {
+          format!("Failed to mount overlay at {:?}", self.target)
+        })?;
+      },
+      _ => self.apply()?,
+    }
+
+    if self.is_bind_mount() {
+      self.remount_bind().with_context(|| {
+        format!("Failed to remount {:?} with security options", self.target)
+      })?;
+    }
+
+    Ok(())
+  }
+
   fn apply(&self) -> Result<()> {
     let (flags, data) = self.options.parse_for_mount();
     if self.uses_loop_device() {
@@ -422,6 +476,17 @@ impl<'a> Mount<'a> {
   ) -> Result<()> {
     mount(Some(source), self.target, self.mount_fstype(), flags, data)
       .map_err(Into::into)
+  }
+
+  fn mount_bind(&self) -> Result<()> {
+    mount(
+      Some(self.source),
+      self.target,
+      None::<&str>,
+      MsFlags::MS_BIND,
+      None::<&str>,
+    )
+    .map_err(Into::into)
   }
 
   fn mount_overlay(&self) -> Result<()> {
@@ -1267,73 +1332,7 @@ fn mount_filesystem(fs_info: &FsInfo, dm: &DeviceManager) -> Result<()> {
     Some(fs_info.fstype.as_str()),
     MountOptions::from_slice(&fs_info.options),
   );
-
-  // Handle special filesystem types
-  match fs_info.fstype.as_str() {
-    "zfs" => {
-      // Mounted by the ZFS userspace tools.
-      log_message(
-        &format!("Skipping mount of {} (handled by kernel)", fs_info.fstype),
-        true,
-      );
-      return Ok(());
-    },
-    "bcachefs" => {
-      // bcachefs device strings may be colon-separated multi-device paths
-      // (e.g. "/dev/sda1:/dev/sda2"). Wait for each component individually
-      // before handing the full joined string to mount.bcachefs.
-      for component in fs_info.device.split(':') {
-        wait_for_device(component, 30, dm).ok();
-      }
-      return mount_bcachefs(
-        &fs_info.device,
-        &fs_info.mountpoint,
-        &fs_info.options,
-        Some(Duration::from_secs(30)),
-      );
-    },
-    "bind" => {
-      // Bind mount
-      mount(
-        Some(fs_info.device.as_str()),
-        &fs_info.mountpoint,
-        None::<&str>,
-        MsFlags::MS_BIND,
-        None::<&str>,
-      )
-      .with_context(|| {
-        format!(
-          "Failed to bind mount {} to {:?}",
-          fs_info.device, fs_info.mountpoint
-        )
-      })?;
-    },
-    "overlay" => {
-      // Overlay mount options include lowerdir/upperdir/workdir and need
-      // preparatory directory creation before the mount syscall.
-      mount_request.mount_overlay().with_context(|| {
-        format!("Failed to mount overlay at {:?}", fs_info.mountpoint)
-      })?;
-    },
-    _ => mount_request.apply()?,
-  }
-
-  // The kernel silently ignores mount flags (nosuid, noexec, nodev, …) on the
-  // initial MS_BIND call. A separate remount is required to enforce them.
-  // The initrd script basically remounts after any bind/rbind mount, which we
-  // should match here.
-  let is_bind = fs_info.fstype == "bind"
-    || fs_info.options.iter().any(|o| o == "bind" || o == "rbind");
-  if is_bind {
-    mount_request.remount_bind().with_context(|| {
-      format!(
-        "Failed to remount {:?} with security options",
-        fs_info.mountpoint
-      )
-    })?;
-  }
-
-  Ok(())
+  mount_request.apply_filesystem(dm)
 }
 
 /// Invoke `mount.bcachefs <device> <mountpoint> [-o opts]`, retrying until

--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -437,11 +437,15 @@ impl<'a> Mount<'a> {
         ),
         true,
       );
-      let loop_device = self
+      let (loop_device, _loop_fd) = self
         .attach_loop_device(flags.contains(MsFlags::MS_RDONLY))
         .with_context(|| {
           format!("Failed to configure loop device for {}", self.source)
         })?;
+
+      // Keep _loop_fd alive until *after* mount() so LO_FLAGS_AUTOCLEAR
+      // does not fire before the kernel has taken its own reference via
+      // blkdev_get_by_path -> lo_open.
       self
         .mount_with_source(loop_device.as_str(), flags, data.as_deref())
         .with_context(|| {
@@ -520,7 +524,7 @@ impl<'a> Mount<'a> {
     .map_err(Into::into)
   }
 
-  fn attach_loop_device(&self, read_only: bool) -> Result<String> {
+  fn attach_loop_device(&self, read_only: bool) -> Result<(String, File)> {
     let backing_file = OpenOptions::new()
       .read(true)
       .write(!read_only)
@@ -579,7 +583,7 @@ impl<'a> Mount<'a> {
         .with_context(|| format!("LOOP_SET_STATUS64 failed for {loop_path}"));
     }
 
-    Ok(loop_path)
+    Ok((loop_path, loop_device))
   }
 }
 

--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -4,7 +4,10 @@ use std::{
   ffi::CString,
   fs::{self, File, OpenOptions, Permissions},
   io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
-  os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt, symlink},
+  os::{
+    fd::AsRawFd,
+    unix::fs::{FileTypeExt, MetadataExt, PermissionsExt, symlink},
+  },
   path::{Path, PathBuf},
   process::{Command, ExitStatus, Stdio},
   thread,
@@ -18,6 +21,33 @@ use nix::{
   sys::stat::{Mode, SFlag, makedev, mknod},
   unistd::{chdir, chroot, execv, getpid},
 };
+
+const LO_FLAGS_READ_ONLY: u32 = 1;
+const LO_FLAGS_AUTOCLEAR: u32 = 4;
+const LOOP_SET_FD: libc::c_ulong = 0x4C00;
+const LOOP_CLR_FD: libc::c_ulong = 0x4C01;
+const LOOP_SET_STATUS64: libc::c_ulong = 0x4C04;
+const LOOP_CTL_GET_FREE: libc::c_ulong = 0x4C82;
+const LO_NAME_SIZE: usize = 64;
+const LO_KEY_SIZE: usize = 32;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct LoopInfo64 {
+  lo_device:           u64,
+  lo_inode:            u64,
+  lo_rdevice:          u64,
+  lo_offset:           u64,
+  lo_sizelimit:        u64,
+  lo_number:           u32,
+  lo_encrypt_type:     u32,
+  lo_encrypt_key_size: u32,
+  lo_flags:            u32,
+  lo_file_name:        [u8; LO_NAME_SIZE],
+  lo_crypt_name:       [u8; LO_NAME_SIZE],
+  lo_encrypt_key:      [u8; LO_KEY_SIZE],
+  lo_init:             [u64; 2],
+}
 
 #[derive(Debug)]
 enum DeviceManager {
@@ -258,6 +288,234 @@ struct FsInfo {
   mountpoint: PathBuf,
   fstype:     String,
   options:    Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MountOptions {
+  raw: Vec<String>,
+}
+
+impl MountOptions {
+  fn from_vec(raw: Vec<String>) -> Self {
+    Self { raw }
+  }
+
+  fn from_slice(raw: &[String]) -> Self {
+    Self { raw: raw.to_vec() }
+  }
+
+  fn from_csv(raw: &str) -> Self {
+    Self {
+      raw: raw
+        .split(',')
+        .filter(|opt| !opt.is_empty())
+        .map(String::from)
+        .collect(),
+    }
+  }
+
+  fn parse_for_mount(&self) -> (MsFlags, Option<String>) {
+    let filtered = self
+      .raw
+      .iter()
+      .map(String::as_str)
+      .filter(|opt| !opt.is_empty() && !opt.starts_with("x-") && *opt != "loop")
+      .collect::<Vec<_>>();
+    parse_mount_options(filtered.iter().copied())
+  }
+
+  fn raw_for_mount(&self) -> Vec<&str> {
+    self
+      .raw
+      .iter()
+      .map(String::as_str)
+      .filter(|opt| !opt.is_empty() && !opt.starts_with("x-") && *opt != "loop")
+      .collect()
+  }
+}
+
+#[derive(Debug, Clone)]
+struct Mount<'a> {
+  source:  &'a str,
+  target:  &'a Path,
+  fstype:  Option<&'a str>,
+  options: MountOptions,
+}
+
+impl<'a> Mount<'a> {
+  fn new(
+    source: &'a str,
+    target: &'a Path,
+    fstype: Option<&'a str>,
+    options: MountOptions,
+  ) -> Self {
+    Self {
+      source,
+      target,
+      fstype,
+      options,
+    }
+  }
+
+  fn source_path(&self) -> &Path {
+    Path::new(self.source)
+  }
+
+  fn mount_fstype(&self) -> Option<&str> {
+    self
+      .fstype
+      .filter(|value| !value.is_empty() && *value != "auto")
+  }
+
+  fn uses_loop_device(&self) -> bool {
+    fs::metadata(self.source_path())
+      .map(|metadata| metadata.file_type().is_file())
+      .unwrap_or(false)
+  }
+
+  fn apply(&self) -> Result<()> {
+    let (flags, data) = self.options.parse_for_mount();
+    if self.uses_loop_device() {
+      log_message(
+        &format!(
+          "Mounting regular file {} via loop device at {:?}",
+          self.source, self.target
+        ),
+        true,
+      );
+      let loop_device = self
+        .attach_loop_device(flags.contains(MsFlags::MS_RDONLY))
+        .with_context(|| {
+          format!("Failed to configure loop device for {}", self.source)
+        })?;
+      self
+        .mount_with_source(loop_device.as_str(), flags, data.as_deref())
+        .with_context(|| {
+          format!(
+            "Failed to mount {} ({}) via {} at {:?}",
+            self.source,
+            self.mount_fstype().unwrap_or("auto"),
+            loop_device,
+            self.target
+          )
+        })?;
+      return Ok(());
+    }
+
+    self
+      .mount_with_source(self.source, flags, data.as_deref())
+      .with_context(|| {
+        format!(
+          "Failed to mount {} ({}) at {:?}",
+          self.source,
+          self.mount_fstype().unwrap_or("auto"),
+          self.target
+        )
+      })
+  }
+
+  fn mount_with_source(
+    &self,
+    source: &str,
+    flags: MsFlags,
+    data: Option<&str>,
+  ) -> Result<()> {
+    mount(Some(source), self.target, self.mount_fstype(), flags, data)
+      .map_err(Into::into)
+  }
+
+  fn mount_overlay(&self) -> Result<()> {
+    let filtered_opts = self.options.raw_for_mount();
+    for opt in &filtered_opts {
+      for prefix in &["upperdir=", "workdir="] {
+        if let Some(path) = opt.strip_prefix(prefix) {
+          fs::create_dir_all(path).ok();
+        }
+      }
+    }
+    mount(
+      Some("overlay"),
+      self.target,
+      Some("overlay"),
+      MsFlags::empty(),
+      Some(filtered_opts.join(",").as_str()),
+    )
+    .map_err(Into::into)
+  }
+
+  fn remount_bind(&self) -> Result<()> {
+    let (flags, data) = self.options.parse_for_mount();
+    mount(
+      None::<&str>,
+      self.target,
+      None::<&str>,
+      MsFlags::MS_REMOUNT | MsFlags::MS_BIND | flags,
+      data.as_deref(),
+    )
+    .map_err(Into::into)
+  }
+
+  fn attach_loop_device(&self, read_only: bool) -> Result<String> {
+    let backing_file = OpenOptions::new()
+      .read(true)
+      .write(!read_only)
+      .open(self.source_path())
+      .with_context(|| {
+        format!("Failed to open loop backing file {}", self.source)
+      })?;
+    let loop_control = OpenOptions::new()
+      .read(true)
+      .write(true)
+      .open("/dev/loop-control")
+      .context("Failed to open /dev/loop-control")?;
+
+    let loop_number =
+      unsafe { libc::ioctl(loop_control.as_raw_fd(), LOOP_CTL_GET_FREE, 0) };
+    if loop_number < 0 {
+      return Err(std::io::Error::last_os_error())
+        .context("LOOP_CTL_GET_FREE failed");
+    }
+
+    let loop_path = format!("/dev/loop{loop_number}");
+    let loop_device = OpenOptions::new()
+      .read(true)
+      .write(true)
+      .open(&loop_path)
+      .with_context(|| format!("Failed to open loop device {loop_path}"))?;
+
+    let set_fd = unsafe {
+      libc::ioctl(
+        loop_device.as_raw_fd(),
+        LOOP_SET_FD,
+        backing_file.as_raw_fd(),
+      )
+    };
+    if set_fd < 0 {
+      return Err(std::io::Error::last_os_error())
+        .with_context(|| format!("LOOP_SET_FD failed for {loop_path}"));
+    }
+
+    let mut loop_info: LoopInfo64 = unsafe { std::mem::zeroed() };
+    loop_info.lo_flags = LO_FLAGS_AUTOCLEAR;
+    if read_only {
+      loop_info.lo_flags |= LO_FLAGS_READ_ONLY;
+    }
+    let file_name = self.source_path().as_os_str().as_encoded_bytes();
+    let copy_len = file_name.len().min(loop_info.lo_file_name.len());
+    loop_info.lo_file_name[..copy_len].copy_from_slice(&file_name[..copy_len]);
+
+    let set_status = unsafe {
+      libc::ioctl(loop_device.as_raw_fd(), LOOP_SET_STATUS64, &loop_info)
+    };
+    if set_status < 0 {
+      let err = std::io::Error::last_os_error();
+      let _ = unsafe { libc::ioctl(loop_device.as_raw_fd(), LOOP_CLR_FD, 0) };
+      return Err(err)
+        .with_context(|| format!("LOOP_SET_STATUS64 failed for {loop_path}"));
+    }
+
+    Ok(loop_path)
+  }
 }
 
 impl KernelCmdline {
@@ -1003,6 +1261,13 @@ fn mount_filesystem(fs_info: &FsInfo, dm: &DeviceManager) -> Result<()> {
     })?;
   }
 
+  let mount_request = Mount::new(
+    &fs_info.device,
+    &fs_info.mountpoint,
+    Some(fs_info.fstype.as_str()),
+    MountOptions::from_slice(&fs_info.options),
+  );
+
   // Handle special filesystem types
   match fs_info.fstype.as_str() {
     "zfs" => {
@@ -1044,50 +1309,13 @@ fn mount_filesystem(fs_info: &FsInfo, dm: &DeviceManager) -> Result<()> {
       })?;
     },
     "overlay" => {
-      // Overlay mount - options are in the format:
-      // lowerdir=...,upperdir=...,workdir=... Filter x- options (kernel
-      // doesn't understand them) and ensure upperdir/workdir exist.
-      let filtered_opts: Vec<&str> = fs_info
-        .options
-        .iter()
-        .filter(|o| !o.starts_with("x-"))
-        .map(std::string::String::as_str)
-        .collect();
-      for opt in &filtered_opts {
-        for prefix in &["upperdir=", "workdir="] {
-          if let Some(path) = opt.strip_prefix(prefix) {
-            fs::create_dir_all(path).ok();
-          }
-        }
-      }
-      mount(
-        Some("overlay"),
-        &fs_info.mountpoint,
-        Some("overlay"),
-        MsFlags::empty(),
-        Some(filtered_opts.join(",").as_str()),
-      )
-      .with_context(|| {
+      // Overlay mount options include lowerdir/upperdir/workdir and need
+      // preparatory directory creation before the mount syscall.
+      mount_request.mount_overlay().with_context(|| {
         format!("Failed to mount overlay at {:?}", fs_info.mountpoint)
       })?;
     },
-    _ => {
-      let (flags, opts_str) =
-        parse_mount_options(fs_info.options.iter().map(String::as_str));
-      mount(
-        Some(fs_info.device.as_str()),
-        &fs_info.mountpoint,
-        Some(fs_info.fstype.as_str()),
-        flags,
-        opts_str.as_deref(),
-      )
-      .with_context(|| {
-        format!(
-          "Failed to mount {} ({}) at {:?}",
-          fs_info.device, fs_info.fstype, fs_info.mountpoint
-        )
-      })?;
-    },
+    _ => mount_request.apply()?,
   }
 
   // The kernel silently ignores mount flags (nosuid, noexec, nodev, …) on the
@@ -1097,16 +1325,7 @@ fn mount_filesystem(fs_info: &FsInfo, dm: &DeviceManager) -> Result<()> {
   let is_bind = fs_info.fstype == "bind"
     || fs_info.options.iter().any(|o| o == "bind" || o == "rbind");
   if is_bind {
-    let (remount_flags, remount_data) =
-      parse_mount_options(fs_info.options.iter().map(String::as_str));
-    mount(
-      None::<&str>,
-      &fs_info.mountpoint,
-      None::<&str>,
-      MsFlags::MS_REMOUNT | MsFlags::MS_BIND | remount_flags,
-      remount_data.as_deref(),
-    )
-    .with_context(|| {
+    mount_request.remount_bind().with_context(|| {
       format!(
         "Failed to remount {:?} with security options",
         fs_info.mountpoint
@@ -1392,15 +1611,13 @@ fn mount_root(
   // Mount the root filesystem
   fs::create_dir_all(target_root)?;
 
-  let (flags, opts_str) =
-    parse_mount_options(mount_opts.iter().map(String::as_str));
-  mount(
-    Some(mount_device),
+  Mount::new(
+    mount_device,
     target_root,
     Some(fstype.as_str()),
-    flags,
-    opts_str.as_deref(),
+    MountOptions::from_vec(mount_opts),
   )
+  .apply()
   .with_context(|| {
     format!("Failed to mount root filesystem {mount_device} at {target_root:?}")
   })?;
@@ -2371,15 +2588,14 @@ pub fn run(args: &[String]) -> Result<()> {
       }
       fs::create_dir_all(&target)?;
 
-      let (flags, data) = parse_mount_options(options.split(','));
-      let opts = data.as_deref();
-      if let Err(e) = mount(
-        Some(device.as_str()),
+      let mount_result = Mount::new(
+        device,
         &target,
         Some(fstype.as_str()),
-        flags,
-        opts,
-      ) {
+        MountOptions::from_csv(options),
+      )
+      .apply();
+      if let Err(e) = mount_result {
         fail(
           &format!(
             "Early mount script: failed to mount {device} at {target:?}: {e}"

--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -383,6 +383,16 @@ impl<'a> Mount<'a> {
   }
 
   fn apply_filesystem(&self, dm: &DeviceManager) -> Result<()> {
+    if self.is_bind_mount() {
+      self.mount_bind().with_context(|| {
+        format!("Failed to bind mount {} to {:?}", self.source, self.target)
+      })?;
+      self.remount_bind().with_context(|| {
+        format!("Failed to remount {:?} with security options", self.target)
+      })?;
+      return Ok(());
+    }
+
     match self.fstype {
       Some("zfs") => {
         log_message(
@@ -405,23 +415,12 @@ impl<'a> Mount<'a> {
           Some(Duration::from_secs(30)),
         );
       },
-      Some("bind") => {
-        self.mount_bind().with_context(|| {
-          format!("Failed to bind mount {} to {:?}", self.source, self.target)
-        })?;
-      },
       Some("overlay") => {
         self.mount_overlay().with_context(|| {
           format!("Failed to mount overlay at {:?}", self.target)
         })?;
       },
       _ => self.apply()?,
-    }
-
-    if self.is_bind_mount() {
-      self.remount_bind().with_context(|| {
-        format!("Failed to remount {:?} with security options", self.target)
-      })?;
     }
 
     Ok(())
@@ -525,6 +524,8 @@ impl<'a> Mount<'a> {
   }
 
   fn attach_loop_device(&self, read_only: bool) -> Result<(String, File)> {
+    load_module("loop").ok();
+
     let backing_file = OpenOptions::new()
       .read(true)
       .write(!read_only)

--- a/nix/vm-tests/loopmount.nix
+++ b/nix/vm-tests/loopmount.nix
@@ -1,0 +1,76 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+# mount(2) does not do mount(8)'s loop auto-setup.
+mkTest {
+  name = "nixos-core-loopmount";
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      squashfsImage =
+        pkgs.runCommand "loopmount-test.squashfs"
+          {
+            nativeBuildInputs = [ pkgs.squashfsTools ];
+          }
+          ''
+            mkdir -p input
+            echo "squashfs-loop-marker" > input/marker
+            mksquashfs input "$out" -comp zstd -no-progress -all-root
+          '';
+    in
+    {
+      imports = [
+        nixosModule
+        testCommons
+      ];
+      system.nixos-core.enable = true;
+
+      boot = {
+        loader.grub.enable = false;
+        initrd.systemd.enable = false;
+
+        initrd.availableKernelModules = [
+          "loop"
+          "squashfs"
+        ];
+        initrd.kernelModules = [
+          "loop"
+          "squashfs"
+        ];
+
+        initrd.extraFiles."/loopmount-test.squashfs".source = squashfsImage;
+      };
+
+      virtualisation.fileSystems."/var/squash" = {
+        device = "/loopmount-test.squashfs";
+        fsType = "squashfs";
+        options = [
+          "loop"
+          "ro"
+        ];
+        neededForBoot = true;
+      };
+    };
+
+  # On failure, systemd waits on the missing mount. We keep that timeout short.
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target", timeout=120)
+
+    with subtest("squashfs mount succeeds against a regular-file source"):
+      machine.succeed("mountpoint -q /var/squash")
+      fstype = machine.succeed("findmnt -n -o FSTYPE /var/squash").strip()
+      assert fstype == "squashfs", f"expected squashfs, got {fstype!r}"
+
+    with subtest("squashfs contents are readable post-switch_root"):
+      content = machine.succeed("cat /var/squash/marker").strip()
+      assert content == "squashfs-loop-marker", f"got {content!r}"
+
+    with subtest("no stage1 ENOTBLK or mount warning"):
+      machine.fail("journalctl -b --no-pager | grep -E 'ENOTBLK|Block device required'")
+      machine.fail("journalctl -b --no-pager | grep -F 'Warning: failed to mount'")
+  '';
+}

--- a/nix/vm-tests/specialfs.nix
+++ b/nix/vm-tests/specialfs.nix
@@ -3,6 +3,17 @@
   nixosModule,
   testCommons,
 }: let
+  # Take a pkgs argument so to use the node's own pkgs in case we decide
+  # to modify then node's own pkgs with overlays etc.
+  squashfsImage = {pkgs}:
+    pkgs.runCommand "stage1-loop-squashfs.img" {
+      nativeBuildInputs = [pkgs.squashfsTools];
+    } ''
+      mkdir root
+      printf '%s\n' loop-mount-ok > root/marker
+      mksquashfs root $out -noappend -all-root
+    '';
+
   mkMachine = {withSystemd}: {
     imports = [nixosModule testCommons];
     system.nixos-core.enable = true;
@@ -43,6 +54,28 @@ in
           device = "/bind-src";
           fsType = "none";
           options = ["bind"];
+          neededForBoot = true;
+        };
+      };
+
+      loopFileMount = {pkgs, ...}: {
+        imports = [nixosModule testCommons];
+        system.nixos-core.enable = true;
+        boot = {
+          loader.grub.enable = false;
+          supportedFilesystems = ["squashfs"]; # FIXME: see if this necessary
+          initrd = {
+            systemd.enable = false;
+            availableKernelModules = ["loop" "squashfs"];
+
+            extraFiles."/loop.squashfs".source = squashfsImage {inherit pkgs;};
+          };
+        };
+
+        virtualisation.fileSystems."/mnt/loop-image" = {
+          device = "/loop.squashfs";
+          fsType = "squashfs";
+          options = ["ro"];
           neededForBoot = true;
         };
       };
@@ -107,6 +140,23 @@ in
       with subtest("file bind-mount: no stage1 mount warnings"):
         fileBindMount.fail(
           "journalctl -b --no-pager | grep -F 'Warning: failed to mount'"
+        )
+
+      loopFileMount.start()
+      loopFileMount.wait_for_unit("multi-user.target")
+
+      with subtest("loop-backed squashfs from initrd mounts during stage1"):
+        loopFileMount.succeed("mountpoint -q /mnt/loop-image")
+        fstype = loopFileMount.succeed(
+          "findmnt -n -o FSTYPE /mnt/loop-image"
+        ).strip()
+        assert fstype == "squashfs", f"expected squashfs, got {fstype!r}"
+        content = loopFileMount.succeed("cat /mnt/loop-image/marker").strip()
+        assert content == "loop-mount-ok", f"got {content!r}"
+
+      with subtest("loop-backed squashfs mount produces no stage1 warnings"):
+        loopFileMount.fail(
+          "journalctl -b --no-pager | grep -F 'Warning: failed to mount /mnt/loop-image'"
         )
     '';
   }


### PR DESCRIPTION
Stage1 now detects when a mount source is a regular file, attaches it to a loop device using Linux loop ioctls directly from Rust, and then performs the mount through the existing Rust `mount(2)` path. 

Since I was happy with the code, I also ended up consolidating the mount flow behind a `Mount`
abstraction so loop-backed mounts, bind remounts, overlay handling, and normal mounts are easier to follow and maintain in one place.