### PR TITLE
nix/vm-tests: cover regular-file squashfs loop mounts

### DIFF
--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -7,18 +7,29 @@ on:
     branches: [main]
 
 jobs:
+  discover:
+    name: Discover tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - id: list
+        run: |
+          tests=$(nix eval --json .#checks.x86_64-linux --apply builtins.attrNames)
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+
   vm-tests:
     name: VM Tests
+    needs: discover
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        test: [boot, etc, users]
+        test: ${{ fromJson(needs.discover.outputs.tests) }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-
+      - uses: cachix/install-nix-action@v31
       - name: Build ${{ matrix.test }} test
         run: nix build .#checks.x86_64-linux.${{ matrix.test }} -Lv

--- a/nix/vm-tests/loopmount.nix
+++ b/nix/vm-tests/loopmount.nix
@@ -1,0 +1,76 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+# mount(2) does not do mount(8)'s loop auto-setup.
+mkTest {
+  name = "nixos-core-loopmount";
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      squashfsImage =
+        pkgs.runCommand "loopmount-test.squashfs"
+          {
+            nativeBuildInputs = [ pkgs.squashfsTools ];
+          }
+          ''
+            mkdir -p input
+            echo "squashfs-loop-marker" > input/marker
+            mksquashfs input "$out" -comp zstd -no-progress -all-root
+          '';
+    in
+    {
+      imports = [
+        nixosModule
+        testCommons
+      ];
+      system.nixos-core.enable = true;
+
+      boot = {
+        loader.grub.enable = false;
+        initrd.systemd.enable = false;
+
+        initrd.availableKernelModules = [
+          "loop"
+          "squashfs"
+        ];
+        initrd.kernelModules = [
+          "loop"
+          "squashfs"
+        ];
+
+        initrd.extraFiles."/loopmount-test.squashfs".source = squashfsImage;
+      };
+
+      virtualisation.fileSystems."/var/squash" = {
+        device = "/loopmount-test.squashfs";
+        fsType = "squashfs";
+        options = [
+          "loop"
+          "ro"
+        ];
+        neededForBoot = true;
+      };
+    };
+
+  # On failure, systemd waits on the missing mount. We keep that timeout short.
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target", timeout=120)
+
+    with subtest("squashfs mount succeeds against a regular-file source"):
+      machine.succeed("mountpoint -q /var/squash")
+      fstype = machine.succeed("findmnt -n -o FSTYPE /var/squash").strip()
+      assert fstype == "squashfs", f"expected squashfs, got {fstype!r}"
+
+    with subtest("squashfs contents are readable post-switch_root"):
+      content = machine.succeed("cat /var/squash/marker").strip()
+      assert content == "squashfs-loop-marker", f"got {content!r}"
+
+    with subtest("no stage1 ENOTBLK or mount warning"):
+      machine.fail("journalctl -b --no-pager | grep -E 'ENOTBLK|Block device required'")
+      machine.fail("journalctl -b --no-pager | grep -F 'Warning: failed to mount'")
+  '';
+}


### PR DESCRIPTION
Exercise the path where stage1 mounts a squashfs image stored as a
regular file in the initrd. The test preloads loop and squashfs so
failures stay focused on loop setup, not module loading. 

(side note, we could maybe modprobe loop before opening `/dev/loop-control`...)

Also, derive the CI matrix from the flake checks, so new VM tests do not
need a workflow edit. This keeps CI tied to nix/vm-tests instead of a
second hand-maintained list.