### PR TITLE
stage1: honor bind option before loop mounts

### DIFF
--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -382,6 +382,10 @@ impl<'a> Mount<'a> {
         .any(|opt| opt == "bind" || opt == "rbind")
   }
 
+  fn is_recursive_bind_mount(&self) -> bool {
+    self.options.raw.iter().any(|opt| opt == "rbind")
+  }
+
   fn apply_filesystem(&self, dm: &DeviceManager) -> Result<()> {
     if self.is_bind_mount() {
       self.mount_bind().with_context(|| {
@@ -482,11 +486,17 @@ impl<'a> Mount<'a> {
   }
 
   fn mount_bind(&self) -> Result<()> {
+    let flags = if self.is_recursive_bind_mount() {
+      MsFlags::MS_BIND | MsFlags::MS_REC
+    } else {
+      MsFlags::MS_BIND
+    };
+
     mount(
       Some(self.source),
       self.target,
       None::<&str>,
-      MsFlags::MS_BIND,
+      flags,
       None::<&str>,
     )
     .map_err(Into::into)
@@ -2380,6 +2390,7 @@ fn parse_mount_options<'a>(
       "strictatime" => flags |= MsFlags::MS_STRICTATIME,
       "lazytime" => flags |= MsFlags::MS_LAZYTIME,
       "bind" => flags |= MsFlags::MS_BIND,
+      "rbind" => flags |= MsFlags::MS_BIND | MsFlags::MS_REC,
       "remount" => flags |= MsFlags::MS_REMOUNT,
       "silent" => flags |= MsFlags::MS_SILENT,
       "dirsync" => flags |= MsFlags::MS_DIRSYNC,

--- a/nix/vm-tests/specialfs.nix
+++ b/nix/vm-tests/specialfs.nix
@@ -58,6 +58,31 @@ in
         };
       };
 
+      recursiveBindMount = {
+        imports = [nixosModule testCommons];
+        system.nixos-core.enable = true;
+        boot = {
+          loader.grub.enable = false;
+          initrd.systemd.enable = false;
+        };
+
+        virtualisation.fileSystems = {
+          "/rbind-src/nested" = {
+            device = "tmpfs";
+            fsType = "tmpfs";
+            options = ["mode=0755"];
+            neededForBoot = true;
+          };
+
+          "/var/rbound" = {
+            device = "/mnt-root/rbind-src";
+            fsType = "none";
+            options = ["rbind"];
+            neededForBoot = true;
+          };
+        };
+      };
+
       loopFileMount = {pkgs, ...}: {
         imports = [nixosModule testCommons];
         system.nixos-core.enable = true;
@@ -140,6 +165,21 @@ in
       with subtest("file bind-mount: no stage1 mount warnings"):
         fileBindMount.fail(
           "journalctl -b --no-pager | grep -F 'Warning: failed to mount'"
+        )
+
+      recursiveBindMount.start()
+      recursiveBindMount.wait_for_unit("multi-user.target")
+
+      with subtest("recursive bind-mount: child mount is preserved"):
+        recursiveBindMount.succeed("mountpoint -q /var/rbound/nested")
+        fstype = recursiveBindMount.succeed(
+          "findmnt -n -o FSTYPE /var/rbound/nested"
+        ).strip()
+        assert fstype == "tmpfs", f"expected nested tmpfs, got {fstype!r}"
+
+      with subtest("recursive bind-mount: no stage1 mount warnings"):
+        recursiveBindMount.fail(
+          "journalctl -b --no-pager | grep -F 'Warning: failed to mount /var/rbound'"
         )
 
       loopFileMount.start()


### PR DESCRIPTION
Bind mounts need to be handled before the loop-device path, since
`fsType = "none"` entries are not image-backed filesystems. For rbind,
preserve nested mounts with `MS_REC` and cover the behavior with a VM
test that fails when the child mount is dropped.