### PR TITLE
musl: add support

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -1,0 +1,22 @@
+name: Cross Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  musl:
+    name: musl cross-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - name: Build nixos-core-musl
+        run: nix build .#nixos-core-musl -L
+      - name: Verify binary is musl-linked
+        run: |
+          file result/bin/nixos-core
+          # Dynamic musl binaries use an ld-musl interpreter.
+          file result/bin/nixos-core | grep -q ld-musl

--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -24,10 +24,10 @@ use nix::{
 
 const LO_FLAGS_READ_ONLY: u32 = 1;
 const LO_FLAGS_AUTOCLEAR: u32 = 4;
-const LOOP_SET_FD: libc::c_ulong = 0x4C00;
-const LOOP_CLR_FD: libc::c_ulong = 0x4C01;
-const LOOP_SET_STATUS64: libc::c_ulong = 0x4C04;
-const LOOP_CTL_GET_FREE: libc::c_ulong = 0x4C82;
+const LOOP_SET_FD: libc::Ioctl = 0x4C00;
+const LOOP_CLR_FD: libc::Ioctl = 0x4C01;
+const LOOP_SET_STATUS64: libc::Ioctl = 0x4C04;
+const LOOP_CTL_GET_FREE: libc::Ioctl = 0x4C82;
 const LO_NAME_SIZE: usize = 64;
 const LO_KEY_SIZE: usize = 32;
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,17 @@
     inherit (nixpkgs.lib) genAttrs systems;
     forEachSystem = genAttrs systems.doubles.linux;
     pkgsForEach = system: import nixpkgs { inherit system; };
+
+    # Build system -> matching pkgsCross musl target.
+    # powerpc-linux is omitted because packages.powerpc-linux is unevaluatable.
+    muslCrossAttr = {
+      x86_64-linux    = "musl64";
+      i686-linux      = "musl32";
+      aarch64-linux   = "aarch64-multiplatform-musl";
+      armv6l-linux    = "muslpi";
+      powerpc64-linux = "ppc64-musl";
+      riscv64-linux   = "riscv64-musl";
+    };
   in {
     nixosModules = {
       nixos-core = import ./nix/modules/nixos.nix self;
@@ -26,10 +37,17 @@
     in
       import ./nix/checks self {inherit pkgs;});
 
-    packages = forEachSystem (system: {
-      inherit ((pkgsForEach system).extend self.overlays.default) nixos-core;
-      default = self.packages.${system}.nixos-core;
-    });
+    packages = forEachSystem (system: let
+      pkgs = pkgsForEach system;
+      muslAttr = muslCrossAttr.${system} or null;
+    in
+      {
+        inherit (pkgs.extend self.overlays.default) nixos-core;
+        default = self.packages.${system}.nixos-core;
+      }
+      // nixpkgs.lib.optionalAttrs (muslAttr != null) {
+        nixos-core-musl = (pkgs.pkgsCross.${muslAttr}.extend self.overlays.default).nixos-core;
+      });
 
     devShells = forEachSystem (system: {
       default = (pkgsForEach system).callPackage ./nix/shell.nix {};


### PR DESCRIPTION
- Fixes #23

- Use `libc::Ioctl` for the loop-device request constants so stage1 follows
the ioctl type exposed by the active libc. glibc and musl disagree on
that width, and the old c_ulong constants made the musl build fail.

- `pkgsCross` musl targets was chosen so the package can keep using the cached
glibc Rust toolchain instead of rebuilding rustc under `pkgsMusl`. Systems
without a matching musl cross target skip nixos-core-musl.

- CI now builds the musl package and checks the resulting interpreter.