### PR TITLE
stage1: fix fsck -t and strip userspace-only mount options

### DIFF
--- a/crates/stage1/src/lib.rs
+++ b/crates/stage1/src/lib.rs
@@ -1299,7 +1299,7 @@ fn run_fsck(device: &str, fstype: &str, _options: &[String]) -> Result<bool> {
   }
 
   let mut cmd = Command::new("fsck");
-  cmd.arg("-a").arg("-T").arg(device);
+  cmd.arg("-a").arg("-t").arg(fstype).arg("-T").arg(device);
 
   // Add filesystem type specific options
   match fstype {
@@ -2472,7 +2472,10 @@ fn parse_mount_options<'a>(
   for opt in opts {
     match opt {
       "ro" => flags |= MsFlags::MS_RDONLY,
-      "rw" | "exec" | "async" | "" => {},
+      // userspace-only options are silently handled by mount(8), but must be
+      // stripped before mount(2)
+      "defaults" | "auto" | "noauto" | "user" | "nouser" | "_netdev"
+      | "nofail" | "rw" | "exec" | "async" | "" => {},
       "nosuid" => flags |= MsFlags::MS_NOSUID,
       "nodev" => flags |= MsFlags::MS_NODEV,
       "noexec" => flags |= MsFlags::MS_NOEXEC,


### PR DESCRIPTION
fsck was missing -t so it would try to call fsck.auto, which doesn't exist in the NixOS initrd causing the system to not boot.

the previous NixOS stage1 scripts used mount(8) which silently eats options like `defaults` before the syscall, but we're calling mount(2) directly so they pass straight through as filesystem data which also causes the system to not boot on some filesystems like ext4.