### PR TITLE
build: tag 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activation-common"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
 ]
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "init-script"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "nixos-core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "setup-etc"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "stage1"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "stage2"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "activation-common",
  "anyhow",
@@ -906,7 +906,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "update-users-groups"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ edition      = "2024"
 license      = "MPL-2.0"
 repository   = "https://github.com/feel-co/nixos-core"
 rust-version = "1.94.0"
-version      = "0.1.0"
+version      = "1.0.0"
 
 [workspace.dependencies]
 # Internal components
-activation-common   = { path = "./crates/activation-common", version = "0.1.0" }
-init-script         = { path = "./crates/init-script", version = "0.1.0" }
-setup-etc           = { path = "./crates/setup-etc", version = "0.1.0" }
-stage1              = { path = "./crates/stage1", version = "0.1.0" }
-stage2              = { path = "./crates/stage2", version = "0.1.0" }
-update-users-groups = { path = "./crates/update-users-groups", version = "0.1.0" }
+activation-common   = { path = "./crates/activation-common", version = "1.0.0" }
+init-script         = { path = "./crates/init-script", version = "1.0.0" }
+setup-etc           = { path = "./crates/setup-etc", version = "1.0.0" }
+stage1              = { path = "./crates/stage1", version = "1.0.0" }
+stage2              = { path = "./crates/stage2", version = "1.0.0" }
+update-users-groups = { path = "./crates/update-users-groups", version = "1.0.0" }
 
 anyhow = "1.0.102"
 clap = { version = "4.6.1", default-features = false, features = [


### PR DESCRIPTION
We're finally ready to call nixos-core stable, i.e., we're [1.0.0 ready](https://github.com/manic-systems/nixos-core/milestone/1) It's been tested in production by many brave individuals already, and our testing setup is now good enough to catch most issues. 

Change-Id: I97bc16cbec65c038c91b81a95024ccc16a6a6964