### PR TITLE
flake: avoid importing nixpkgs and overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   }: let
     inherit (nixpkgs.lib) genAttrs systems;
     forEachSystem = genAttrs systems.doubles.linux;
-    pkgsForEach = system: import nixpkgs { inherit system; };
+    pkgsForEach = system: nixpkgs.legacyPackages.${system};
 
     # Build system -> matching pkgsCross musl target.
     # powerpc-linux is omitted because packages.powerpc-linux is unevaluatable.
@@ -27,7 +27,7 @@
 
     overlays = {
       nixos-core = final: _prev: {
-        nixos-core = final.callPackage ./nix/package.nix {};
+        nixos-core = self.packages.${final.stdenv.hostPlatform.system}.nixos-core;
       };
       default = self.overlays.nixos-core;
     };
@@ -42,11 +42,11 @@
       muslAttr = muslCrossAttr.${system} or null;
     in
       {
-        inherit (pkgs.extend self.overlays.default) nixos-core;
+        nixos-core = pkgs.callPackage ./nix/package.nix {};
         default = self.packages.${system}.nixos-core;
       }
       // nixpkgs.lib.optionalAttrs (muslAttr != null) {
-        nixos-core-musl = (pkgs.pkgsCross.${muslAttr}.extend self.overlays.default).nixos-core;
+        nixos-core-musl = pkgs.pkgsCross.${muslAttr}.callPackage ./nix/package.nix {};
       });
 
     devShells = forEachSystem (system: {

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -11,7 +11,7 @@ self: {
   inherit (lib.meta) getExe';
 
   # Keep the default package on the caller's pkgs, including cross stdenvs.
-  pkgsWithOverlay = pkgs.extend self.overlays.nixos-core;
+  customPackages = self.packages.${pkgs.stdenv.hostPlatform.system};
 
   udev = config.systemd.package;
   extra-utils = config.system.build.extraUtils;
@@ -278,8 +278,8 @@ self: {
 in {
   options.system.nixos-core = {
     enable = mkEnableOption "nixos-core multi-call binary";
-    package = mkPackageOption pkgsWithOverlay "nixos-core" {
-      pkgsText = literalExpression "pkgs.extend nixos-core.overlays.nixos-core";
+    package = mkPackageOption customPackages "nixos-core" {
+      pkgsText = literalExpression "nixos-core.packages.\${system}";
     };
 
     strictActivation = mkOption {


### PR DESCRIPTION
For performance reasons. No longer requires a separate instance of nixpkgs, and the overlay is no longer used inside the module, since we can just grab the package from self.