### PR TITLE
nixos: do modprobe and firmware setup only at activation

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -169,6 +169,9 @@ self: {
     '';
   };
 
+  nixosInitCompat = cfg.components.nixosInitCompat.enable;
+  nixosInitCompatFlags = optionalString nixosInitCompat " --setup-fhs --create-current-system";
+
   # top-level.nix does `substituteInPlace $out/init --subst-var-by systemConfig $out`
   # after copying bootStage2, so @systemConfig@ must be a literal string here.
   bootStage2 = pkgs.writeTextFile {
@@ -190,13 +193,11 @@ self: {
       }
       export STAGE2_GREETING=${escapeShellArg "<<< ${config.system.nixos.distroName} Stage 2 >>>"}
       ${optionalString cfg.strictActivation "export STAGE2_STRICT_ACTIVATION=true"}
-      ${optionalString cfg.components.nixosInitCompat.enable ''
-        export FIRMWARE_PATH=${escapeShellArg "${config.hardware.firmware}/lib/firmware"}
-        export MODPROBE_BINARY=${escapeShellArg "${getExe' pkgs.kmod "modprobe"}"}
+      ${optionalString nixosInitCompat ''
         export ENV_BINARY=${escapeShellArg config.environment.usrbinenv}
         export SH_BINARY=${escapeShellArg config.environment.binsh}
       ''}
-      exec ${cfg.package}/bin/stage-2-init${optionalString cfg.components.nixosInitCompat.enable " --setup-firmware --setup-modprobe --setup-fhs --create-current-system"}
+      exec ${cfg.package}/bin/stage-2-init${nixosInitCompatFlags}
     '';
   };
 

--- a/nix/vm-tests/container.nix
+++ b/nix/vm-tests/container.nix
@@ -1,0 +1,32 @@
+{
+  mkTest,
+  nixosModule,
+  testCommons,
+}:
+mkTest {
+  name = "nixos-core-container";
+
+  nodes.machine = {
+    imports = [
+      nixosModule
+      testCommons
+    ];
+    system.nixos-core.enable = true;
+    boot.loader.grub.enable = false;
+
+    containers.demo = {
+      autoStart = true;
+      config = {
+        imports = [ nixosModule ];
+        system.nixos-core.enable = true;
+        system.stateVersion = "26.05";
+      };
+    };
+  };
+
+  testScript = ''
+    # A nixos-core container should successfully boot to multi-user under nspawn.
+    machine.wait_for_unit("container@demo.service")
+    machine.wait_until_succeeds("nixos-container run demo -- systemctl is-active multi-user.target")
+  '';
+}


### PR DESCRIPTION
- Closes #38

stage2 was re-doing the modprobe and firmware writes activation already handles, and did so fatally, so nspawn's read-only /proc/sys aborted the whole init.

This commit drops that.