### PR TITLE
setup-etc: migrate direct symlinks out of old smfh manifests

### DIFF
--- a/crates/setup-etc/src/lib.rs
+++ b/crates/setup-etc/src/lib.rs
@@ -11,6 +11,8 @@ use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use smfh_core::manifest::{File as ManifestFile, FileKind, Manifest};
 
+mod manifest_diff;
+
 /// Update /etc from the current NixOS configuration
 #[derive(Parser, Debug)]
 #[command(name = "setup-etc")]
@@ -95,6 +97,9 @@ pub fn run(args: &[String]) -> Result<()> {
     &manifest.direct_symlinks,
   )
   .context("Failed to write direct symlink state")?;
+  let manifest_diff_base =
+    manifest_diff::DiffBase::prepare(&manifest_path, &manifest.direct_symlinks)
+      .context("Failed to prepare manifest diff base")?;
 
   // Steps 6–7: diff and commit; clean up the temp file on any failure so we
   // do not leave a stale .new file behind.
@@ -106,14 +111,14 @@ pub fn run(args: &[String]) -> Result<()> {
       .map_err(|e| anyhow::anyhow!("Failed to parse manifest: {e:?}"))?;
 
     new_manifest
-      .diff(&manifest_path, "", true)
+      .diff(manifest_diff_base.path(), "", true)
       .map_err(|e| anyhow::anyhow!("Failed to apply manifest diff: {e:?}"))?;
 
     activate_direct_symlinks(&manifest.direct_symlinks, &direct_state_path)
       .context("Failed to apply direct symlinks")?;
 
     // Step 7: Commit the new manifest atomically.
-    fs::rename(&manifest_tmp, manifest_path)
+    fs::rename(&manifest_tmp, &manifest_path)
       .context("Failed to commit manifest")?;
     fs::rename(&direct_state_tmp, &direct_state_path)
       .context("Failed to commit direct symlink state")

--- a/crates/setup-etc/src/manifest_diff.rs
+++ b/crates/setup-etc/src/manifest_diff.rs
@@ -1,0 +1,186 @@
+use std::{
+  collections::HashSet,
+  fs,
+  path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use log::warn;
+
+use crate::DirectSymlink;
+
+/// Diff source for smfh activation.
+///
+/// Old nixos-core releases tracked direct symlinks in the smfh manifest. The
+/// current activation path owns those entries separately, so smfh must not
+/// deactivate them while migrating old state.
+pub(crate) enum DiffBase {
+  Original(PathBuf),
+  Filtered(PathBuf),
+}
+
+impl DiffBase {
+  pub(crate) fn prepare(
+    manifest_path: &Path,
+    direct_symlinks: &[DirectSymlink],
+  ) -> Result<Self> {
+    let Some(filtered) = filtered_old_manifest(manifest_path, direct_symlinks)?
+    else {
+      return Ok(Self::Original(manifest_path.to_path_buf()));
+    };
+
+    let path = PathBuf::from(format!(
+      "{}.diff-base.{}",
+      manifest_path.display(),
+      std::process::id()
+    ));
+    fs::write(&path, filtered).with_context(|| {
+      format!("Failed to write manifest diff base {}", path.display())
+    })?;
+
+    Ok(Self::Filtered(path))
+  }
+
+  pub(crate) fn path(&self) -> &Path {
+    match self {
+      Self::Original(path) | Self::Filtered(path) => path,
+    }
+  }
+}
+
+impl Drop for DiffBase {
+  fn drop(&mut self) {
+    if let Self::Filtered(path) = self {
+      let _ = fs::remove_file(path);
+    }
+  }
+}
+
+fn filtered_old_manifest(
+  manifest_path: &Path,
+  direct_symlinks: &[DirectSymlink],
+) -> Result<Option<String>> {
+  if direct_symlinks.is_empty() {
+    return Ok(None);
+  }
+
+  let contents = match fs::read_to_string(manifest_path) {
+    Ok(contents) => contents,
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+    Err(e) => {
+      return Err(e).with_context(|| {
+        format!("Failed to read {}", manifest_path.display())
+      });
+    },
+  };
+
+  let mut value: serde_json::Value = match serde_json::from_str(&contents) {
+    Ok(value) => value,
+    Err(e) => {
+      warn!(
+        "failed to parse old manifest {} while preparing diff base: {e}",
+        manifest_path.display()
+      );
+      return Ok(None);
+    },
+  };
+
+  let Some(files) = value
+    .get_mut("files")
+    .and_then(|files| files.as_array_mut())
+  else {
+    return Ok(None);
+  };
+
+  let direct_targets: HashSet<PathBuf> = direct_symlinks
+    .iter()
+    .map(|link| link.target.clone())
+    .collect();
+  let original_len = files.len();
+  files.retain(|file| {
+    file
+      .get("target")
+      .and_then(|target| target.as_str())
+      .is_none_or(|target| !direct_targets.contains(Path::new(target)))
+  });
+
+  if files.len() == original_len {
+    return Ok(None);
+  }
+
+  Ok(Some(serde_json::to_string_pretty(&value)?))
+}
+
+#[cfg(test)]
+mod tests {
+  use tempfile::TempDir;
+
+  use super::*;
+
+  fn write_manifest(path: &Path, targets: &[&str]) {
+    let files = targets
+      .iter()
+      .map(|target| {
+        serde_json::json!({
+          "source": "/etc/static/source",
+          "target": target,
+          "kind": "Symlink",
+          "clobber": true
+        })
+      })
+      .collect::<Vec<_>>();
+    fs::write(
+      path,
+      serde_json::json!({"version": 1, "files": files}).to_string(),
+    )
+    .unwrap();
+  }
+
+  fn direct_symlink(target: &str) -> DirectSymlink {
+    DirectSymlink {
+      source: PathBuf::from("/proc/mounts"),
+      target: PathBuf::from(target),
+    }
+  }
+
+  fn manifest_targets(contents: &str) -> Vec<String> {
+    let value: serde_json::Value = serde_json::from_str(contents).unwrap();
+    value["files"]
+      .as_array()
+      .unwrap()
+      .iter()
+      .map(|file| file["target"].as_str().unwrap().to_string())
+      .collect()
+  }
+
+  #[test]
+  fn prunes_current_direct_symlink_targets() {
+    let dir = TempDir::new().unwrap();
+    let manifest_path = dir.path().join("etc-manifest.json");
+    write_manifest(&manifest_path, &["/etc/mtab", "/etc/hostname"]);
+
+    let filtered =
+      filtered_old_manifest(&manifest_path, &[direct_symlink("/etc/mtab")])
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(manifest_targets(&filtered), vec!["/etc/hostname"]);
+    assert_eq!(
+      manifest_targets(&fs::read_to_string(&manifest_path).unwrap()),
+      vec!["/etc/mtab", "/etc/hostname"]
+    );
+  }
+
+  #[test]
+  fn reuses_manifest_without_direct_symlink_targets() {
+    let dir = TempDir::new().unwrap();
+    let manifest_path = dir.path().join("etc-manifest.json");
+    write_manifest(&manifest_path, &["/etc/hostname"]);
+
+    let filtered =
+      filtered_old_manifest(&manifest_path, &[direct_symlink("/etc/mtab")])
+        .unwrap();
+
+    assert!(filtered.is_none());
+  }
+}

--- a/nix/vm-tests/etc.nix
+++ b/nix/vm-tests/etc.nix
@@ -5,6 +5,19 @@
   testCommons,
   writeText,
 }:
+let
+  oldDirectSymlinkManifest = writeText "old-direct-symlink-manifest.json" (builtins.toJSON {
+    version = 1;
+    files = [
+      {
+        source = "/proc/mounts";
+        target = "/etc/mtab";
+        type = "symlink";
+        clobber = true;
+      }
+    ];
+  });
+in
 mkTest ({nodes, ...}: {
   name = "nixos-core-etc";
   nodes = {
@@ -159,6 +172,16 @@ mkTest ({nodes, ...}: {
     with subtest("direct symlink state contains expected entries"):
       machine.succeed("grep -q nixos-core-direct /var/lib/nixos/etc-direct-symlinks.json")
       machine.succeed("grep -q localtime /var/lib/nixos/etc-direct-symlinks.json")
+
+    with subtest("old smfh direct-symlink manifest migrates without deactivating mtab"):
+      machine.succeed("cp ${oldDirectSymlinkManifest} /var/lib/nixos/etc-manifest.json")
+      machine.succeed("rm -f /etc/mtab && ln -s /proc/999999999/mounts /etc/mtab")
+      machine.fail("test -e /proc/999999999/mounts")
+      machine.succeed("/run/current-system/activate")
+      machine.succeed("test -L /etc/mtab")
+      machine.succeed("readlink /etc/mtab | grep -qx /proc/mounts")
+      machine.succeed("grep -q '\"target\": \"/etc/mtab\"' /var/lib/nixos/etc-direct-symlinks.json")
+      machine.fail("grep -q '\"target\": \"/etc/mtab\"' /var/lib/nixos/etc-manifest.json")
 
     with subtest("idempotent re-activation"):
       machine.execute("/run/current-system/activate")


### PR DESCRIPTION
Newer setup-etc stores direct symlinks in `etc-direct-symlinks.json`, but an
old `etc-manifest.json` can still contain `/etc/mtab`. During activation,
smfh tries to deactivate that stale manifest entry before nixos-core
recreates the direct symlink. For `/etc/mtab`, this can fail when the target
resolves through `/proc/self/mounts` to a dead `/proc/<pid>/mounts`.

Before diffing, current direct-symlink targets are omitted from the old manifest
and are then applied by the dedicated direct-symlink activation path.

Closes #44.