### PR TITLE
make nixos-core module compatible with etc overlay and sysusers/userborn

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -455,8 +455,8 @@ in {
         enable =
           mkEnableOption ""
           // {
-            default = !config.systemd.sysusers.enable;
-            defaultText = literalExpression "!config.systemd.sysusers.enable";
+            default = !config.services.userborn.enable && !config.systemd.sysusers.enable;
+            defaultText = literalExpression "!config.services.userborn.enable && !config.systemd.sysusers.enable";
             description = "Whether to create users and groups with nixos-core";
           };
 

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -537,12 +537,12 @@ in {
         message = "nixos-core supersedes nixos-init, and cannot be used alongside it";
       }
       {
-        assertion = !config.system.etc.overlay.enable;
-        message = "nixos-core cannot be used with system.etc.overlay.enable";
+        assertion = !cfg.components.etcActivation.enable || !config.system.etc.overlay.enable;
+        message = "system.nixos-core.components.etcActivation.enable cannot be used with system.etc.overlay.enable. Disable one of them.";
       }
       {
-        assertion = !config.services.userborn.enable && !config.systemd.sysusers.enable;
-        message = "nixos-core cannot be used with services.userborn.enable or systemd.sysusers.enable";
+        assertion = !cfg.components.userGroupsActivation.enable || (!config.services.userborn.enable && !config.systemd.sysusers.enable);
+        message = "system.nixos-core.components.userGroupsActivation.enable cannot be used with services.userborn.enable or systemd.sysusers.enable. Disable one of them.";
       }
     ];
   };


### PR DESCRIPTION
this updates the assertions so the `nixos-core` module can be used alongside `etc.overlay`, `systemd-sysusers`, and `userborn`